### PR TITLE
Add Resolve Dependencies Controller

### DIFF
--- a/Hive.Dependencies.Tests/ResolverTests.cs
+++ b/Hive.Dependencies.Tests/ResolverTests.cs
@@ -70,8 +70,6 @@ namespace Hive.Dependencies.Tests
             public VersionRange Range(ModRef @ref) => @ref.Range;
 
             public Version Version(Mod mod_) => mod_.Version;
-
-            public bool IsValidVersionRange(VersionRange @ref) => @ref != null;
         }
 
         [Fact]

--- a/Hive.Dependencies/Exceptions.fs
+++ b/Hive.Dependencies/Exceptions.fs
@@ -5,8 +5,7 @@ type VersionNotFoundException<'ModRef>(ref: 'ModRef) =
     member public _.ModReference = ref
     override _.Message = base.Message + " " + ref.ToString()
 
-type DependencyRangeInvalidException<'VerRange>(id: string, range: 'VerRange) =
+type DependencyRangeInvalidException(id: string) =
     inherit exn("Could not resolve valid version range for mod")
     member public _.ID = id
-    member public _.Range = range
-    override _.Message = "Mod " + id + " has no version matching range " + range.ToString()
+    override _.Message = base.Message + " " + id

--- a/Hive.Dependencies/IValueAccessor.fs
+++ b/Hive.Dependencies/IValueAccessor.fs
@@ -21,7 +21,6 @@ type IValueAccessor<'Mod, 'ModRef, 'Version, 'VerRange> =
         abstract member ID : ref:'ModRef -> string;
         abstract member Range : ref:'ModRef -> 'VerRange;
         abstract member CreateRef : id:string -> range:'VerRange -> 'ModRef
-        abstract member IsValidVersionRange : ref:'VerRange -> bool;
 
         // Comparisons
         abstract member Matches : range:'VerRange -> version:'Version -> bool;

--- a/Hive.Dependencies/Resolver.fs
+++ b/Hive.Dependencies/Resolver.fs
@@ -35,12 +35,8 @@ type private ResolveImpl<'Mod, 'ModRef, 'Version, 'VerRange>(access: IValueAcces
         |> Helpers.mapKeyValues
         |> Seq.map (fun struct(id, range) ->
             match range with
-            | ValueSome r ->
-                if access.IsValidVersionRange r then
-                    access.CreateRef id r
-                else
-                    raise (DependencyRangeInvalidException(id, r))
-            | _ -> raise (DependencyRangeInvalidException(id, range)))
+            | ValueSome r -> access.CreateRef id r
+            | _ -> raise (DependencyRangeInvalidException id))
 
     /// The primary recursive function that resolves dependencies.
     static member private resolveLoop (access: IValueAccessor<'Mod, 'ModRef, 'Version, 'VerRange>) collectReqs mods =

--- a/Hive.Tests/Endpoints/ResolveDependenciesController.cs
+++ b/Hive.Tests/Endpoints/ResolveDependenciesController.cs
@@ -239,7 +239,7 @@ namespace Hive.Tests.Endpoints
             var dependencyResult = result.Value as DependencyResolutionResult;
             Assert.NotEmpty(dependencyResult!.ConflictingMods); // Make sure we have a conflicting mod.
             var mod = dependencyResult!.ConflictingMods.First();
-            Assert.Equal("BS_Utils", mod.ModID); // Ensure that the conflicting mod is BS_Utils; BS+ conflicts with it while SongCore depends on it
+            Assert.Equal("BS_Utils", mod); // Ensure that the conflicting mod is BS_Utils; BS+ conflicts with it while SongCore depends on it
         }
 
         [Fact]

--- a/Hive/Models/DependencyResolutionResult.cs
+++ b/Hive/Models/DependencyResolutionResult.cs
@@ -7,7 +7,7 @@ namespace Hive.Models
         public string Message { get; set; } = null!;
         public List<Mod> AdditionalMods { get; } = new List<Mod>();
         public List<ModReference> MissingMods { get; } = new List<ModReference>();
-        public List<ModReference> ConflictingMods { get; } = new List<ModReference>();
+        public List<string> ConflictingMods { get; } = new List<string>();
         public List<ModReference> VersionMismatches { get; } = new List<ModReference>();
     }
 }


### PR DESCRIPTION
This PR adds implementation and testing for the `POST /resolve_dependencies` endpoint.

It also contains other code fixes for Mods Controller which I mistakenly added to the branch while we were discussing using ASP.NET to de-serialize the contents of the request body. There's still a bit more to do in that aspect, but that should be handled in its own branch, probably when we abstract some common functionality for use by both GQL and REST.