### PR TITLE
Fix Issues With Uploading Workflow

### DIFF
--- a/api/reference/hive.v1.yaml
+++ b/api/reference/hive.v1.yaml
@@ -495,12 +495,14 @@ paths:
               type: object
               additionalProperties: false
               properties:
-                finalMetadata:
-                  $ref: '#/components/schemas/Mod'
+                finalMetadataJson:
+                  type: string
+                  description: A JSON string which represents the final metadata of the mod.
                 cookie:
                   type: string
+                  description: The action cookie from the first stage of uploading.
               required:
-                - finalMetadata
+                - finalMetadataJson
                 - cookie
         description: The final mod metadata to upload and the cookie returned in response to a successful completion of the first upload step.
       security:

--- a/src/Hive.Tests/Endpoints/UploadController.cs
+++ b/src/Hive.Tests/Endpoints/UploadController.cs
@@ -20,6 +20,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -106,7 +107,13 @@ namespace Hive.Tests.Endpoints
                 Dependencies = ImmutableList.Create(new ModReference("bsipa", new VersionRange("^4.0.0"))),
             };
 
-            var result2 = await controller.CompleteUpload(data, result1.Value.ActionCookie!);
+            var jsonString = JsonSerializer.Serialize(data, new()
+            {
+                // We need to explicitly include fields for some ValueTuples to serialize properly
+                IncludeFields = true
+            });
+
+            var result2 = await controller.CompleteUpload(jsonString, result1.Value.ActionCookie!);
 
             Assert.NotNull(result2);
             Assert.Null(result2.Result);

--- a/src/Hive/Controllers/UploadController.cs
+++ b/src/Hive/Controllers/UploadController.cs
@@ -232,6 +232,7 @@ namespace Hive.Controllers
             /// The type of result that this structure represents.
             /// </summary>
             [JsonPropertyName("type")]
+            [JsonConverter(typeof(JsonStringEnumConverter))]
             public ResultType Type { get; init; }
 
             /// <summary>

--- a/src/Hive/Controllers/UploadController.cs
+++ b/src/Hive/Controllers/UploadController.cs
@@ -437,7 +437,11 @@ namespace Hive.Controllers
         // ^^^ returned when the object associated with the upload was deleted automatically. Basically, "You took too long"
         public async Task<ActionResult<UploadResult>> CompleteUpload([FromForm] string finalMetadataJson, [FromForm] string cookie)
         {
-            var finalMetadata = JsonSerializer.Deserialize<SerializedMod>(finalMetadataJson);
+            var finalMetadata = JsonSerializer.Deserialize<SerializedMod>(finalMetadataJson, new()
+            {
+                // We need to explicitly include fields for some ValueTuples to deserialize properly
+                IncludeFields = true,
+            });
 
             if (finalMetadata is null || cookie is null)
                 return BadRequest();

--- a/src/Hive/Controllers/UploadController.cs
+++ b/src/Hive/Controllers/UploadController.cs
@@ -423,7 +423,7 @@ namespace Hive.Controllers
         /// <summary>
         /// The final stage of the upload flow. Completes an upload by providing the final metadata of the mod.
         /// </summary>
-        /// <param name="finalMetadata">The final mod metadata to upload.</param>
+        /// <param name="finalMetadataJson">A JSON string which represents the final mod metadata to upload.</param>
         /// <param name="cookie">The cookie returned in the response to the first stage.</param>
         /// <returns>An <see cref="UploadResult"/> repersenting the upload operation. If it completes normally with a
         /// <see cref="ResultType"/> of <see cref="ResultType.Success"/>, the upload was successful.</returns>
@@ -434,8 +434,10 @@ namespace Hive.Controllers
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status410Gone)]
         // ^^^ returned when the object associated with the upload was deleted automatically. Basically, "You took too long"
-        public async Task<ActionResult<UploadResult>> CompleteUpload([FromForm] SerializedMod finalMetadata, [FromForm] string cookie)
+        public async Task<ActionResult<UploadResult>> CompleteUpload([FromForm] string finalMetadataJson, [FromForm] string cookie)
         {
+            var finalMetadata = JsonSerializer.Deserialize<SerializedMod>(finalMetadataJson);
+
             if (finalMetadata is null || cookie is null)
                 return BadRequest();
 

--- a/src/Hive/Models/Serialized/SerializedMod.cs
+++ b/src/Hive/Models/Serialized/SerializedMod.cs
@@ -91,6 +91,7 @@ namespace Hive.Models.Serialized
         /// The additional data associated with this <see cref="Mod"/>.
         /// All properties are public and readonly for all people who get mods.
         /// </summary>
+        [JsonConverter(typeof(ArbitraryAdditionalData.ArbitraryAdditionalDataConverter))]
         public ArbitraryAdditionalData AdditionalData { get; init; } = new();
 
         /// <summary>


### PR DESCRIPTION
This PR fixes some issues encountered with the upload workflow as I was testing the File System CDN Provider plugin.

Namely:
- Use Enum string converter for the `ResultType` enum (to show human readable text instead of numbers)
- Use one JSON string for `finalMetadata` (instead of having to specify each part separately in the form), this had problems with `SerializedMod.Version`
- Add missing converter for `SerializedMod.AdditionalData` to parse incoming additional data