### PR TITLE
Switch to using DryIoc as our DI system

### DIFF
--- a/src/Hive.Plugins.Tests.TestPlugin/Startup.cs
+++ b/src/Hive.Plugins.Tests.TestPlugin/Startup.cs
@@ -21,6 +21,12 @@ namespace Hive.Plugins.Tests.TestPlugin
             _ = services;
         }
 
+        public void ConfigureContainer(object? container)
+        {
+            _ = Configuration;
+            _ = container;
+        }
+
         public void PreConfigure(IEnumerable<Action> preConfigCbs)
         {
             if (preConfigCbs is null)

--- a/src/Hive.Plugins.Tests/TestAggregable.cs
+++ b/src/Hive.Plugins.Tests/TestAggregable.cs
@@ -51,6 +51,11 @@ namespace Hive.Plugins.Tests
 
     public class TestAggregable
     {
+        private class EmptyServiceProvider : IServiceProvider
+        {
+            public object? GetService(Type serviceType) => null;
+        }
+
         [Fact]
         public void TestStopIfReturns()
         {
@@ -69,9 +74,10 @@ namespace Hive.Plugins.Tests
             expected = true;
             retTrue2.Setup(m => m.Test2(out expected));
 
-            var created = new Aggregate<ITestStopIfReturns>(new List<ITestStopIfReturns>(){
+            var created = new Aggregate<ITestStopIfReturns>(new List<ITestStopIfReturns>
+            {
                 retTrue1.Object, retFalse.Object, retTrue2.Object
-            });
+            }, new EmptyServiceProvider());
             // Should return upon the first false returned
             Assert.False(created.Instance.Test1());
             created.Instance.Test2(out var tmp);
@@ -108,9 +114,10 @@ namespace Hive.Plugins.Tests
             var expected2 = new List<int>();
             retTrue2.Setup(m => m.Test2(out expected2));
 
-            var created = new Aggregate<ITestStopIfReturnsNull>(new List<ITestStopIfReturnsNull>(){
+            var created = new Aggregate<ITestStopIfReturnsNull>(new List<ITestStopIfReturnsNull>
+            {
                 retTrue1.Object, retFalse.Object, retTrue2.Object
-            });
+            }, new EmptyServiceProvider());
             // Should return upon the first null returned
             Assert.Null(created.Instance.Test1());
             created.Instance.Test2(out var tmp);
@@ -159,7 +166,7 @@ namespace Hive.Plugins.Tests
                 plugins.Add(plugin);
             }
 
-            var created = new Aggregate<ITestStopIfReturnsEmptyGeneric>(plugins.Select(x => x.Object));
+            var created = new Aggregate<ITestStopIfReturnsEmptyGeneric>(plugins.Select(x => x.Object), new EmptyServiceProvider());
 
             // If StopIfReturnsEmpty fails, then an exception will be thrown here.
             Assert.Empty(created.Instance.RemoveNumber(numbers));
@@ -206,7 +213,7 @@ namespace Hive.Plugins.Tests
                 plugins.Add(plugin);
             }
 
-            var created = new Aggregate<ITestStopIfReturnsEmptyNonGeneric>(plugins.Select(x => x.Object));
+            var created = new Aggregate<ITestStopIfReturnsEmptyNonGeneric>(plugins.Select(x => x.Object), new EmptyServiceProvider());
 
             // If StopIfReturnsEmpty fails, then an exception will be thrown here.
             Assert.Empty(created.Instance.RemoveElement(data));
@@ -228,9 +235,10 @@ namespace Hive.Plugins.Tests
             var test2 = new Mock<ITestCarryReturnValue>();
             test2.Setup(m => m.Test1(It.IsAny<int>())).Returns((int x) => x * -1);
 
-            var created = new Aggregate<ITestCarryReturnValue>(new List<ITestCarryReturnValue>(){
+            var created = new Aggregate<ITestCarryReturnValue>(new List<ITestCarryReturnValue>
+            {
                 test1.Object, test2.Object
-            });
+            }, new EmptyServiceProvider());
             // Should go till completion, return (x + 1) * -1
             Assert.Equal(-2, created.Instance.Test1(1));
             // Should have called both functions identically once

--- a/src/Hive.Plugins/Aggregates/AggregableAttribute.cs
+++ b/src/Hive.Plugins/Aggregates/AggregableAttribute.cs
@@ -8,6 +8,9 @@ namespace Hive.Plugins.Aggregates
     [AttributeUsage(AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
     public sealed class AggregableAttribute : Attribute
     {
+        /// <summary>
+        /// Gets the type of the default implementation for this aggregate. This will be used if no services of the aggregated type are registered.
+        /// </summary>
         public Type? Default { get; set; }
     }
 }

--- a/src/Hive.Plugins/Aggregates/AggregableAttribute.cs
+++ b/src/Hive.Plugins/Aggregates/AggregableAttribute.cs
@@ -8,5 +8,6 @@ namespace Hive.Plugins.Aggregates
     [AttributeUsage(AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
     public sealed class AggregableAttribute : Attribute
     {
+        public Type? Default { get; set; }
     }
 }

--- a/src/Hive.Plugins/Aggregates/Aggregate.cs
+++ b/src/Hive.Plugins/Aggregates/Aggregate.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Hive.Plugins.Aggregates
 {
@@ -13,9 +14,10 @@ namespace Hive.Plugins.Aggregates
         /// Creates an aggregate instance from the provided enumerable of <typeparamref name="T"/>.
         /// </summary>
         /// <param name="aggregate">The collection to create the aggregation with.</param>
-        public Aggregate(IEnumerable<T> aggregate)
+        /// <param name="services">The service provider to use to construct the default implementation, if any.</param>
+        public Aggregate(IEnumerable<T> aggregate, IServiceProvider services)
         {
-            Instance = AggregatedInstanceGenerator<T>.Create(aggregate);
+            Instance = AggregatedInstanceGenerator<T>.Create(aggregate, services);
         }
 
         /// <inheritdoc/>

--- a/src/Hive.Plugins/Loading/ContainerConfigurator.cs
+++ b/src/Hive.Plugins/Loading/ContainerConfigurator.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Hosting;
+
+namespace Hive.Plugins.Loading
+{
+    internal class ContainerConfigurator
+    {
+        private readonly List<Action<HostBuilderContext, object>> actions = new();
+
+        public void Run(HostBuilderContext hostContext, object container)
+        {
+            foreach (var action in actions)
+            {
+                action(hostContext, container);
+            }
+        }
+
+        public void ConfigureContainer<TContainer>(Action<HostBuilderContext, TContainer> action)
+            => actions.Add((hc, c) => action(hc, (TContainer)c));
+        public void ConfigureContainerNoCtx<TContainer>(Action<TContainer> action)
+            => ConfigureContainer<TContainer>((_, c) => action(c));
+    }
+}

--- a/src/Hive.Plugins/Loading/PluginHostBuilderExtensions.cs
+++ b/src/Hive.Plugins/Loading/PluginHostBuilderExtensions.cs
@@ -23,15 +23,18 @@ namespace Hive.Plugins.Loading
             if (configureOptions is null)
                 throw new ArgumentNullException(nameof(builder));
 
+            var configurator = new ContainerConfigurator();
+
             return builder.ConfigureServices((ctx, services) =>
                 {
                     var builder = new PluginLoaderOptionsBuilder();
                     configureOptions(builder);
 
                     var config = ctx.Configuration.GetSection(builder.ConfigurationKey);
-                    var loader = new PluginLoader(config, builder);
+                    var loader = new PluginLoader(config, builder, configurator);
                     loader.LoadPlugins(services, ctx.HostingEnvironment);
-                });
+                })
+                .ConfigureContainer<object>(configurator.Run);
         }
     }
 }

--- a/src/Hive.Tests/DIHelper.cs
+++ b/src/Hive.Tests/DIHelper.cs
@@ -10,7 +10,6 @@ using System;
 using System.Collections.Generic;
 using Xunit.Abstractions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using GraphQL;
@@ -18,7 +17,6 @@ using System.Threading.Tasks;
 using Hive.Graphing;
 using DryIoc;
 using DryIoc.Microsoft.DependencyInjection;
-using static Hive.Tests.ModTestHelper;
 using Hive.Plugins.Aggregates;
 
 namespace Hive.Tests

--- a/src/Hive.Tests/Endpoints/ChannelsController.cs
+++ b/src/Hive.Tests/Endpoints/ChannelsController.cs
@@ -1,7 +1,6 @@
 ﻿using DryIoc;
 using Hive.Models;
 using Hive.Permissions;
-using Hive.Plugins;
 using Hive.Services.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Hive.Tests/Endpoints/ChannelsController.cs
+++ b/src/Hive.Tests/Endpoints/ChannelsController.cs
@@ -1,4 +1,5 @@
-﻿using Hive.Models;
+﻿using DryIoc;
+using Hive.Models;
 using Hive.Permissions;
 using Hive.Plugins;
 using Hive.Services.Common;
@@ -158,8 +159,9 @@ namespace Hive.Tests.Endpoints
             ruleProvider.Setup(m => m.TryGetRule(filterChannels.Name, out filterChannels)).Returns(true);
             ruleProvider.Setup(m => m.TryGetRule(createChannel.Name, out createChannel)).Returns(true);
 
-            var services = DIHelper.ConfigureServices(
+            var container = DIHelper.ConfigureServices(
                 Options,
+                _ => { },
                 helper,
                 ruleProvider.Object,
                 new List<(string, Delegate)>
@@ -167,13 +169,13 @@ namespace Hive.Tests.Endpoints
                     ("isNull", new Func<object?, bool>(o => o is null))
                 });
 
-            services.AddSingleton<IChannelsControllerPlugin>(sp => new HiveChannelsControllerPlugin());
-            services.AddSingleton(sp => plugin);
-            services.AddAggregates();
-            services.AddScoped<ChannelService>();
-            services.AddScoped<Controllers.ChannelsController>();
+            container.RegisterInstance(plugin);
+            container.Register<ChannelService>(Reuse.Scoped);
+            container.Register<Controllers.ChannelsController>(Reuse.Scoped);
 
-            var controller = services.BuildServiceProvider().GetRequiredService<Controllers.ChannelsController>();
+            var scope = container.CreateScope();
+
+            var controller = scope.ServiceProvider.GetRequiredService<Controllers.ChannelsController>();
 
             controller.ControllerContext = new ControllerContext()
             {

--- a/src/Hive.Tests/Endpoints/GameVersionsController.cs
+++ b/src/Hive.Tests/Endpoints/GameVersionsController.cs
@@ -2,7 +2,6 @@
 using Hive.Models;
 using Hive.Models.Serialized;
 using Hive.Permissions;
-using Hive.Plugins;
 using Hive.Services.Common;
 using Hive.Plugins.Aggregates;
 using Hive.Utilities;

--- a/src/Hive.Tests/Endpoints/ModsController.cs
+++ b/src/Hive.Tests/Endpoints/ModsController.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using DryIoc;
 using Hive.Models;
 using Hive.Models.Serialized;
 using Hive.Plugins;
@@ -363,15 +364,15 @@ namespace Hive.Tests.Endpoints
 
         private Controllers.ModsController CreateController(string permissionRule, IEnumerable<IModsPlugin> plugins)
         {
-            var services = DIHelper.ConfigureServices(Options, helper, new ModTestHelper.ModsRuleProvider(permissionRule));
+            var container = DIHelper.ConfigureServices(Options, _ => { }, helper, new ModTestHelper.ModsRuleProvider(permissionRule));
 
-            services
-                .AddTransient(sp => plugins)
-                .AddScoped<ModService>()
-                .AddScoped<Controllers.ModsController>()
-                .AddAggregates();
+            container.RegisterInstance(plugins);
+            container.Register<ModService>(Reuse.Scoped);
+            container.Register<Controllers.ModsController>(Reuse.Scoped);
 
-            var controller = services.BuildServiceProvider().GetRequiredService<Controllers.ModsController>();
+            var scope = container.CreateScope();
+
+            var controller = scope.ServiceProvider.GetRequiredService<Controllers.ModsController>();
 
             controller.ControllerContext = new ControllerContext()
             {

--- a/src/Hive.Tests/Endpoints/ModsController.cs
+++ b/src/Hive.Tests/Endpoints/ModsController.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using DryIoc;
 using Hive.Models;
 using Hive.Models.Serialized;
-using Hive.Plugins;
 using Hive.Services.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Hive.Tests/Endpoints/ResolveDependenciesController.cs
+++ b/src/Hive.Tests/Endpoints/ResolveDependenciesController.cs
@@ -1,7 +1,6 @@
 ﻿using DryIoc;
 using Hive.Models;
 using Hive.Permissions;
-using Hive.Plugins;
 using Hive.Services.Common;
 using Hive.Utilities;
 using Hive.Versioning;

--- a/src/Hive.Tests/Endpoints/ResolveDependenciesController.cs
+++ b/src/Hive.Tests/Endpoints/ResolveDependenciesController.cs
@@ -1,4 +1,5 @@
-﻿using Hive.Models;
+﻿using DryIoc;
+using Hive.Models;
 using Hive.Permissions;
 using Hive.Plugins;
 using Hive.Services.Common;
@@ -270,24 +271,17 @@ namespace Hive.Tests.Endpoints
 
         private Controllers.ResolveDependenciesController CreateController(string permissionRule, IEnumerable<IResolveDependenciesPlugin>? plugins = null)
         {
-            var services = DIHelper.ConfigureServices(Options, helper, new ResolveDependenciesRuleProvider(permissionRule));
+            var container = DIHelper.ConfigureServices(Options, _ => { }, helper, new ResolveDependenciesRuleProvider(permissionRule));
 
-            if (plugins is null)
-            {
-                plugins = new[] { new HiveResolveDependenciesControllerPlugin() };
-            }
-            else
-            {
-                plugins = plugins.Prepend(new HiveResolveDependenciesControllerPlugin());
-            }
+            plugins ??= Enumerable.Empty<IResolveDependenciesPlugin>();
 
-            services
-                .AddTransient(sp => plugins)
-                .AddScoped<DependencyResolverService>()
-                .AddScoped<Controllers.ResolveDependenciesController>()
-                .AddAggregates();
+            container.RegisterInstance(plugins);
+            container.Register<DependencyResolverService>(Reuse.Scoped);
+            container.Register<Controllers.ResolveDependenciesController>(Reuse.Scoped);
 
-            var controller = services.BuildServiceProvider().GetRequiredService<Controllers.ResolveDependenciesController>();
+            var scope = container.CreateScope();
+
+            var controller = scope.ServiceProvider.GetRequiredService<Controllers.ResolveDependenciesController>();
 
             controller.ControllerContext = new ControllerContext()
             {

--- a/src/Hive.Tests/Endpoints/UploadController.cs
+++ b/src/Hive.Tests/Endpoints/UploadController.cs
@@ -2,7 +2,6 @@
 using Hive.Models;
 using Hive.Models.Serialized;
 using Hive.Permissions;
-using Hive.Plugins;
 using Hive.Plugins.Aggregates;
 using Hive.Services;
 using Hive.Utilities;

--- a/src/Hive.Tests/Endpoints/UploadController.cs
+++ b/src/Hive.Tests/Endpoints/UploadController.cs
@@ -62,12 +62,17 @@ namespace Hive.Tests.Endpoints
             this.helper = helper;
         }
 
+        private class EmptyServiceProvider : IServiceProvider
+        {
+            public object? GetService(Type serviceType) => null;
+        }
+
         [Fact]
         public void EnsureIUploadPluginValid()
         {
             var emptyPlugin = new HiveDefaultUploadPlugin();
 
-            var aggregate = new Aggregate<IUploadPlugin>(new[] { emptyPlugin });
+            var aggregate = new Aggregate<IUploadPlugin>(new[] { emptyPlugin }, new EmptyServiceProvider());
 
             _ = aggregate.Instance;
         }

--- a/src/Hive.Tests/Graphing/ModQueries.cs
+++ b/src/Hive.Tests/Graphing/ModQueries.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Net;
 using System.Threading.Tasks;
 using DryIoc;
-using DryIoc.Microsoft.DependencyInjection;
 using GraphQL.Execution;
 using Hive.Graphing;
 using Hive.Models;
-using Hive.Plugins;
-using Hive.Plugins.Aggregates;
 using Hive.Services.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hive.Tests/TestHelpers.cs
+++ b/src/Hive.Tests/TestHelpers.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
-using Moq;
 using Xunit;
 
 namespace Hive.Tests

--- a/src/Hive/Controllers/UploadController.cs
+++ b/src/Hive/Controllers/UploadController.cs
@@ -27,7 +27,7 @@ namespace Hive.Controllers
     /// <summary>
     /// A plugin for the mod upload flow.
     /// </summary>
-    [Aggregable]
+    [Aggregable(Default = typeof(HiveDefaultUploadPlugin))]
     public interface IUploadPlugin
     {
         /// <summary>

--- a/src/Hive/Controllers/UserController.cs
+++ b/src/Hive/Controllers/UserController.cs
@@ -13,7 +13,7 @@ namespace Hive.Controllers
     /// <summary>
     /// A plugin used for user related endpoints.
     /// </summary>
-    [Aggregable]
+    [Aggregable(Default = typeof(HiveUserPlugin))]
     public interface IUserPlugin
     {
         /// <summary>

--- a/src/Hive/Graphing/HiveQL.cs
+++ b/src/Hive/Graphing/HiveQL.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using DryIoc;
 using GraphQL;
 using GraphQL.Builders;
-using GraphQL.MicrosoftDI;
 using GraphQL.Server;
 using GraphQL.Types;
 using Hive.Graphing.Types;
@@ -24,7 +24,7 @@ namespace Hive.Graphing
         /// <returns></returns>
         public static IServiceCollection AddHiveGraphQL(this IServiceCollection services)
         {
-            _ = services.AddSingleton(services => new HiveSchema(new SelfActivatingServiceProvider(services)));
+            //_ = services.AddSingleton(services => new HiveSchema(new SelfActivatingServiceProvider(services)));
             _ = services.AddGraphQL((options, provider) =>
             {
                 var logger = provider.GetRequiredService<Serilog.ILogger>();
@@ -32,6 +32,9 @@ namespace Hive.Graphing
             }).AddSystemTextJson();
             return services;
         }
+
+        public static void RegisterHiveGraphQL(this IRegistrator container)
+            => container.Register<HiveSchema>(Reuse.Scoped);
 
         /// <summary>
         /// Analyzes and fills out any errors in an object query.

--- a/src/Hive/Graphing/HiveQL.cs
+++ b/src/Hive/Graphing/HiveQL.cs
@@ -24,7 +24,6 @@ namespace Hive.Graphing
         /// <returns></returns>
         public static IServiceCollection AddHiveGraphQL(this IServiceCollection services)
         {
-            //_ = services.AddSingleton(services => new HiveSchema(new SelfActivatingServiceProvider(services)));
             _ = services.AddGraphQL((options, provider) =>
             {
                 var logger = provider.GetRequiredService<Serilog.ILogger>();

--- a/src/Hive/Graphing/HiveSchema.cs
+++ b/src/Hive/Graphing/HiveSchema.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using DryIoc;
 using GraphQL.Types;
 using GraphQL.Utilities;
 using Hive.Graphing.Types;
@@ -14,7 +15,9 @@ namespace Hive.Graphing
         /// <summary>
         /// Construct a HiveSchema and obtain the <see cref="HiveQuery"/> from the provided <see cref="IServiceProvider"/>.
         /// </summary>
-        /// <param name="provider"></param>
-        public HiveSchema(IServiceProvider provider) : base(provider) => Query = provider.GetRequiredService<HiveQuery>();
+        /// <param name="container"></param>
+        public HiveSchema(IContainer container)
+            : base(container.With(r => r.WithConcreteTypeDynamicRegistrations()))
+            => Query = this.GetRequiredService<HiveQuery>();
     }
 }

--- a/src/Hive/Hive.csproj
+++ b/src/Hive/Hive.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="DryIoc.dll" Version="4.8.1" />
+    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="5.1.0" />
     <PackageReference Include="GraphQL" Version="4.5.0" />
     <PackageReference Include="GraphQL.MicrosoftDI" Version="4.5.0" />
     <PackageReference Include="GraphQL.Server.Core" Version="5.0.2" />

--- a/src/Hive/Program.cs
+++ b/src/Hive/Program.cs
@@ -1,3 +1,4 @@
+using DryIoc.Microsoft.DependencyInjection;
 using Hive.Models;
 using Hive.Plugins.Loading;
 using Hive.Versioning;
@@ -25,15 +26,8 @@ using Version = Hive.Versioning.Version;
 
 namespace Hive
 {
-    /// <summary>
-    ///
-    /// </summary>
     public static class Program
     {
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="args"></param>
         public static async Task Main(string[] args)
         {
             var host = CreateHostBuilder(args).Build();
@@ -70,13 +64,9 @@ namespace Hive
             await host.RunAsync().ConfigureAwait(false);
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="args"></param>
-        /// <returns></returns>
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .UseServiceProviderFactory(new DryIocServiceProviderFactory())
                 .UseSerilog((host, services, logger) => logger
                     .ReadFrom.Configuration(host.Configuration)
                     .Destructure.LibraryTypes()

--- a/src/Hive/Program.cs
+++ b/src/Hive/Program.cs
@@ -26,7 +26,7 @@ using Version = Hive.Versioning.Version;
 
 namespace Hive
 {
-    public static class Program
+    internal static class Program
     {
         public static async Task Main(string[] args)
         {

--- a/src/Hive/Properties/launchSettings.json
+++ b/src/Hive/Properties/launchSettings.json
@@ -11,7 +11,7 @@
   "profiles": {
     "Hive": {
       "commandName": "Project",
-      "workingDirectory": "bin\\Debug\\net5.0\\",
+      "workingDirectory": "..\\..\\artifacts\\bin\\Hive\\Debug",
       "launchBrowser": true,
       "launchUrl": "api/channels",
       "environmentVariables": {

--- a/src/Hive/Properties/launchSettings.json
+++ b/src/Hive/Properties/launchSettings.json
@@ -11,7 +11,7 @@
   "profiles": {
     "Hive": {
       "commandName": "Project",
-      "workingDirectory": "..\\..\\artifacts\\bin\\Hive\\Debug",
+      "workingDirectory": "..\\..\\artifacts\\bin\\Hive\\Debug\\net5.0",
       "launchBrowser": true,
       "launchUrl": "api/channels",
       "environmentVariables": {

--- a/src/Hive/Services/Auth0AuthenticationService.cs
+++ b/src/Hive/Services/Auth0AuthenticationService.cs
@@ -22,7 +22,7 @@ namespace Hive.Services
     /// <summary>
     /// Represents a plugin that handles user creation.
     /// </summary>
-    [Aggregable]
+    [Aggregable(Default = typeof(HiveUsernamePlugin))]
     public interface IUserCreationPlugin
     {
         /// <summary>

--- a/src/Hive/Services/Common/ChannelService.cs
+++ b/src/Hive/Services/Common/ChannelService.cs
@@ -14,7 +14,7 @@ namespace Hive.Services.Common
     /// <summary>
     /// A class for plugins that allow modifications of <see cref="ChannelsController"/>
     /// </summary>
-    [Aggregable]
+    [Aggregable(Default = typeof(HiveChannelsControllerPlugin))]
     public interface IChannelsControllerPlugin
     {
         /// <summary>

--- a/src/Hive/Services/Common/DependencyResolverService.cs
+++ b/src/Hive/Services/Common/DependencyResolverService.cs
@@ -19,7 +19,7 @@ namespace Hive.Services.Common
     /// <summary>
     /// A class for plugins that allow modifications of <see cref="ResolveDependenciesController"/>
     /// </summary>
-    [Aggregable]
+    [Aggregable(Default = typeof(HiveResolveDependenciesControllerPlugin))]
     public interface IResolveDependenciesPlugin
     {
         /// <summary>

--- a/src/Hive/Services/Common/GameVersionService.cs
+++ b/src/Hive/Services/Common/GameVersionService.cs
@@ -16,7 +16,7 @@ namespace Hive.Services.Common
     /// <summary>
     /// A class for plugins that allow modifications of <see cref="GameVersionsController"/>
     /// </summary>
-    [Aggregable]
+    [Aggregable(Default = typeof(HiveGameVersionsControllerPlugin))]
     public interface IGameVersionsPlugin
     {
         /// <summary>

--- a/src/Hive/Services/Common/ModService.cs
+++ b/src/Hive/Services/Common/ModService.cs
@@ -19,7 +19,7 @@ namespace Hive.Services.Common
     /// <summary>
     /// A class for plugins that allow modifications of <see cref="ModsController"/>
     /// </summary>
-    [Aggregable]
+    [Aggregable(Default = typeof(HiveModsControllerPlugin))]
     public interface IModsPlugin
     {
         /// <summary>

--- a/src/Hive/Startup.cs
+++ b/src/Hive/Startup.cs
@@ -20,26 +20,12 @@ using Serilog;
 
 namespace Hive
 {
-    /// <summary>
-    ///
-    /// </summary>
-    public class Startup
+    internal class Startup
     {
-        /// <summary>
-        /// Startup constructor with configuration
-        /// </summary>
-        /// <param name="configuration"></param>
         public Startup(IConfiguration configuration) => Configuration = configuration;
 
-        /// <summary>
-        /// Configuration instance
-        /// </summary>
         public IConfiguration Configuration { get; }
 
-        /// <summary>
-        /// This method gets called by the runtime. Use this method to add services to the container.
-        /// </summary>
-        /// <param name="services"></param>
         public void ConfigureServices(IServiceCollection services)
         {
             _ = services.AddDbContext<HiveContext>(options =>

--- a/src/Hive/Startup.cs
+++ b/src/Hive/Startup.cs
@@ -1,14 +1,18 @@
 using System.Security.Cryptography;
+using DryIoc;
 using Hive.Controllers;
 using Hive.Extensions;
 using Hive.Graphing;
 using Hive.Models;
 using Hive.Permissions;
 using Hive.Plugins;
+using Hive.Plugins.Aggregates;
 using Hive.Services;
 using Hive.Services.Common;
+using Hive.Utilities;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -40,42 +44,11 @@ namespace Hive
         /// <param name="services"></param>
         public void ConfigureServices(IServiceCollection services)
         {
-            _ = services
-                .AddSingleton<IClock>(SystemClock.Instance)
-                .AddTransient<Permissions.Logging.ILogger, Logging.PermissionsProxy>()
-                .AddSingleton(sp =>
-                    new PermissionsManager<PermissionContext>(sp.GetRequiredService<IRuleProvider>(), sp.GetService<Permissions.Logging.ILogger>(), "."))
-                .AddSingleton<IChannelsControllerPlugin, HiveChannelsControllerPlugin>()
-                .AddSingleton<IGameVersionsPlugin, HiveGameVersionsControllerPlugin>()
-                .AddSingleton<IModsPlugin, HiveModsControllerPlugin>()
-                .AddSingleton<IResolveDependenciesPlugin, HiveResolveDependenciesControllerPlugin>()
-                .AddSingleton<IUploadPlugin, HiveDefaultUploadPlugin>()
-                .AddSingleton<IUserCreationPlugin, HiveUsernamePlugin>()
-                .AddSingleton<IUserPlugin, HiveUserPlugin>()
-                .AddSingleton<SymmetricAlgorithm>(sp => Rijndael.Create()); // TODO: pick an algo
-
-            // If the config file doesn't have an Auth0 section, we'll assume that the auth service is provided by a plugin.
-            if (Configuration.GetSection("Auth0").Exists())
-            {
-                _ = services.AddInterfacesAsScoped<Auth0AuthenticationService, IProxyAuthenticationService, IAuth0Service>();
-            }
-            // Uncomment the following code if you need mock authentication for HOPEFULLY DEVELOPMENT reasons
-            //else
-            //{
-            //    _ = services.AddInterfacesAsScoped<MockAuthenticationService, IProxyAuthenticationService, IAuth0Service>();
-            //}
-
             _ = services.AddDbContext<HiveContext>(options =>
                 options.UseNpgsql(Configuration.GetConnectionString("Default"),
                     o => o.UseNodaTime().SetPostgresVersion(12, 0)));
 
-            _ = services.AddHttpContextAccessor();
-            _ = services.AddScoped<ModService>()
-                .AddScoped<ChannelService>()
-                .AddScoped<GameVersionService>()
-                .AddScoped<DependencyResolverService>()
-                .AddAggregates()
-                .AddHiveGraphQL();
+            _ = services.AddHiveGraphQL();
 
             var conditionalFeature = new HiveConditionalControllerFeatureProvider()
                 .RegisterCondition<Auth0Controller>(Configuration.GetSection("Auth0").Exists());
@@ -86,11 +59,40 @@ namespace Hive
                 .ConfigureApplicationPartManager(manager => manager.FeatureProviders.Add(conditionalFeature));
         }
 
-        /// <summary>
-        /// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        /// </summary>
-        /// <param name="app"></param>
-        /// <param name="env"></param>
+        public void ConfigureContainer(IContainer container)
+        {
+            container.RegisterInstance<IClock>(SystemClock.Instance);
+            container.Register<Permissions.Logging.ILogger, Logging.PermissionsProxy>();
+            container.Register(Made.Of(() => new PermissionsManager<PermissionContext>(Arg.Of<IRuleProvider>(), Arg.Of<Permissions.Logging.ILogger>(), ".")), Reuse.Singleton);
+            container.Register<SymmetricAlgorithm>(made: Made.Of(() => Rijndael.Create()));
+
+            if (Configuration.GetSection("Auth0").Exists())
+            {
+                container.RegisterMany<Auth0AuthenticationService>();
+            }
+            else if (container.Resolve<IHostEnvironment>().IsDevelopment())
+            {
+                // if Auth0 isn't configured, and we're in a dev environment, use 
+                container.RegisterMany<MockAuthenticationService>();
+            }
+
+            container.Register<IHttpContextAccessor, HttpContextAccessor>();
+            container.Register<ModService>(Reuse.Scoped);
+            container.Register<ChannelService>(Reuse.Scoped);
+            container.Register<GameVersionService>(Reuse.Scoped);
+            container.Register<DependencyResolverService>(Reuse.Scoped);
+            container.Register(typeof(IAggregate<>), typeof(Aggregate<>));
+
+            // TODO: make this less repetitive and dumb
+            container.Register<IChannelsControllerPlugin, HiveChannelsControllerPlugin>(Reuse.Singleton);
+            container.Register<IGameVersionsPlugin, HiveGameVersionsControllerPlugin>(Reuse.Singleton);
+            container.Register<IModsPlugin, HiveModsControllerPlugin>();
+            container.Register<IResolveDependenciesPlugin, HiveResolveDependenciesControllerPlugin>(Reuse.Singleton);
+            container.Register<IUploadPlugin, HiveDefaultUploadPlugin>(Reuse.Singleton);
+            container.Register<IUserCreationPlugin, HiveUsernamePlugin>(Reuse.Singleton);
+            container.Register<IUserPlugin, HiveUserPlugin>(Reuse.Singleton);
+        }
+
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (Configuration.GetValue<bool>("RestrictEndpoints"))

--- a/src/Hive/Startup.cs
+++ b/src/Hive/Startup.cs
@@ -87,6 +87,8 @@ namespace Hive
             container.Register<GameVersionService>(Reuse.Scoped);
             container.Register<DependencyResolverService>(Reuse.Scoped);
             container.Register(typeof(IAggregate<>), typeof(Aggregate<>), Reuse.Singleton);
+
+            container.RegisterHiveGraphQL();
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/src/Hive/Startup.cs
+++ b/src/Hive/Startup.cs
@@ -1,15 +1,12 @@
 using System.Security.Cryptography;
 using DryIoc;
 using Hive.Controllers;
-using Hive.Extensions;
 using Hive.Graphing;
 using Hive.Models;
 using Hive.Permissions;
-using Hive.Plugins;
 using Hive.Plugins.Aggregates;
 using Hive.Services;
 using Hive.Services.Common;
-using Hive.Utilities;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -82,15 +79,6 @@ namespace Hive
             container.Register<GameVersionService>(Reuse.Scoped);
             container.Register<DependencyResolverService>(Reuse.Scoped);
             container.Register(typeof(IAggregate<>), typeof(Aggregate<>));
-
-            // TODO: make this less repetitive and dumb
-            container.Register<IChannelsControllerPlugin, HiveChannelsControllerPlugin>(Reuse.Singleton);
-            container.Register<IGameVersionsPlugin, HiveGameVersionsControllerPlugin>(Reuse.Singleton);
-            container.Register<IModsPlugin, HiveModsControllerPlugin>();
-            container.Register<IResolveDependenciesPlugin, HiveResolveDependenciesControllerPlugin>(Reuse.Singleton);
-            container.Register<IUploadPlugin, HiveDefaultUploadPlugin>(Reuse.Singleton);
-            container.Register<IUserCreationPlugin, HiveUsernamePlugin>(Reuse.Singleton);
-            container.Register<IUserPlugin, HiveUserPlugin>(Reuse.Singleton);
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/src/Hive/appsettings.json
+++ b/src/Hive/appsettings.json
@@ -35,13 +35,6 @@
 			"Application": "Hive"
 		}
 	},
-	"Auth0": {
-		"Domain": "YOUR_DOMAIN",
-		"Audience": "YOUR_API_IDENTIFIER",
-		"ClientID": "YOUR_MTM_APP_ID",
-		"ClientSecret": "YOUR_MTM_APP_SECRET",
-		"TimeoutMS": 0
-	},
 	"RuleSubfolder": "Rules",
 	"AllowedHosts": "*",
 	"UseRateLimiting": true,

--- a/src/PluginSDK/Hive.Plugin.Sdk/Directory.Build.targets
+++ b/src/PluginSDK/Hive.Plugin.Sdk/Directory.Build.targets
@@ -94,7 +94,7 @@
     <ItemGroup>
       <_PackageInfo>
         <ConditionProp></ConditionProp>
-        <ExtraProps> Private="false" ExcludeAssets="buildTransitive"</ExtraProps>
+        <ExtraProps> Private="false" ExcludeAssets="runtime;buildTransitive"</ExtraProps>
         <ConditionProp Condition="'%(IsRoslynExtension)' == 'true'"> Condition="'%24(EnableHiveAnalyzers)' != 'false'"</ConditionProp>
         <ExtraProps Condition="'%(IsRoslynExtension)' == 'true'"> PrivateAssets="all" IncludeAssets="all"</ExtraProps>
       </_PackageInfo>

--- a/src/PluginSDK/Hive.Plugin.Sdk/Sdk/Sdk.props
+++ b/src/PluginSDK/Hive.Plugin.Sdk/Sdk/Sdk.props
@@ -6,6 +6,7 @@
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
 
     <HiveToolsDirectory>$(MSBuildThisFileDirectory)..\msbtools\</HiveToolsDirectory> <!-- in the package, relative to this file, aka /Sdk/ -->
+    <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
   
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' "/>

--- a/src/PluginSDK/Hive.Plugin.Template/PluginTemplate/Startup.cs
+++ b/src/PluginSDK/Hive.Plugin.Template/PluginTemplate/Startup.cs
@@ -14,9 +14,16 @@ namespace PluginTemplate
         public Startup(IConfiguration config)
             => Configuration = config;
 
+        /*
         public void ConfigureServices(IServiceCollection services)
         {
-            // TODO: Register your services to the IServiceCollection
+            // TODO: Use this only for other libraries which use MSDI for injection
+        }
+        */
+
+        public void ConfigureContainer(IContainer container)
+        {
+            // TODO: Register your services in the IContainer
         }
 
         public /*async Task*/ void PreConfigure/*Async*/()


### PR DESCRIPTION
This PR switches from using MSDI to DryIoc, for the much nicer API it provides. It also adjusts the plugin loader to expose `ConfigureContainer` to plugins, as well as adjusting the plugin SDK to make plugins build correctly by default.