### PR TITLE
Fix JSON Serializer and Friends

### DIFF
--- a/src/Hive.Tests/DIHelper.cs
+++ b/src/Hive.Tests/DIHelper.cs
@@ -55,7 +55,11 @@ namespace Hive.Tests
             // Initial services
             container.RegisterInstance<ILogger>(new LoggerConfiguration().WriteTo.Debug().CreateLogger());
             container.RegisterInstance<IClock>(SystemClock.Instance);
-            container.RegisterInstance(new JsonSerializerOptions());
+            container.RegisterInstance(new JsonSerializerOptions()
+            {
+                // tuples please
+                IncludeFields = true,
+            });
             container.Register<IProxyAuthenticationService, MockAuthenticationService>(Reuse.Singleton);
             container.Register(typeof(IAggregate<>), typeof(Aggregate<>));
             if (outputHelper != null)

--- a/src/Hive.Tests/DIHelper.cs
+++ b/src/Hive.Tests/DIHelper.cs
@@ -55,6 +55,7 @@ namespace Hive.Tests
             // Initial services
             container.RegisterInstance<ILogger>(new LoggerConfiguration().WriteTo.Debug().CreateLogger());
             container.RegisterInstance<IClock>(SystemClock.Instance);
+            container.RegisterInstance(new JsonSerializerOptions());
             container.Register<IProxyAuthenticationService, MockAuthenticationService>(Reuse.Singleton);
             container.Register(typeof(IAggregate<>), typeof(Aggregate<>));
             if (outputHelper != null)

--- a/src/Hive/Controllers/GameVersionsController.cs
+++ b/src/Hive/Controllers/GameVersionsController.cs
@@ -64,7 +64,7 @@ namespace Hive.Controllers
         /// </summary>
         /// <param name="ver">The new game version to create.</param>
         /// <returns>A wrapped <see cref="GameVersion"/> object, if successful.</returns>
-        [HttpPost("/new")]
+        [HttpPost("new")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]

--- a/src/Hive/Middlewares/ExceptionHandlingMiddleware.cs
+++ b/src/Hive/Middlewares/ExceptionHandlingMiddleware.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -21,20 +20,17 @@ namespace Hive
     /// </summary>
     public class ExceptionHandlingMiddleware
     {
-        private static readonly JsonSerializerOptions serializerOptions = new()
-        {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault
-        };
-
         private readonly RequestDelegate _next;
         private readonly Serilog.ILogger logger;
+        private readonly JsonSerializerOptions serializerOptions;
 
         /// <summary>
         /// Create using a given <see cref="RequestDelegate"/> and <see cref="Serilog.ILogger"/>
         /// </summary>
         /// <param name="next"></param>
         /// <param name="log"></param>
-        public ExceptionHandlingMiddleware([DisallowNull] RequestDelegate next, [DisallowNull] Serilog.ILogger log)
+        /// <param name="serializerOptions"></param>
+        public ExceptionHandlingMiddleware([DisallowNull] RequestDelegate next, [DisallowNull] Serilog.ILogger log, JsonSerializerOptions serializerOptions)
         {
             if (next is null)
                 throw new ArgumentNullException(nameof(next));
@@ -42,6 +38,7 @@ namespace Hive
                 throw new ArgumentNullException(nameof(log));
             _next = next;
             logger = log.ForContext<ExceptionHandlingMiddleware>();
+            this.serializerOptions = serializerOptions;
         }
 
         /// <summary>

--- a/src/Hive/Models/Channel.cs
+++ b/src/Hive/Models/Channel.cs
@@ -21,7 +21,7 @@ namespace Hive.Models
         /// </summary>
         [Column(TypeName = "jsonb")]
         [JsonConverter(typeof(ArbitraryAdditionalData.ArbitraryAdditionalDataConverter))]
-        public ArbitraryAdditionalData AdditionalData { get; } = new();
+        public ArbitraryAdditionalData AdditionalData { get; set; } = new();
 
         /// <summary>
         /// Equality comparison

--- a/src/Hive/Models/GameVersion.cs
+++ b/src/Hive/Models/GameVersion.cs
@@ -25,7 +25,7 @@ namespace Hive.Models
         /// </summary>
         [Column(TypeName = "jsonb")]
         [JsonConverter(typeof(ArbitraryAdditionalData.ArbitraryAdditionalDataConverter))]
-        public ArbitraryAdditionalData AdditionalData { get; } = new();
+        public ArbitraryAdditionalData AdditionalData { get; set; } = new();
 
         /// <summary>
         /// The <see cref="Instant"/> this GameVersion was created

--- a/src/Hive/Models/Mod.cs
+++ b/src/Hive/Models/Mod.cs
@@ -97,7 +97,7 @@ namespace Hive.Models
         /// <remarks>This data is publicly read-only. Be sure not to store sensitive information as additional data.</remarks>
         [Column(TypeName = "jsonb")]
         [JsonConverter(typeof(ArbitraryAdditionalData.ArbitraryAdditionalDataConverter))]
-        public ArbitraryAdditionalData AdditionalData { get; } = new();
+        public ArbitraryAdditionalData AdditionalData { get; set; } = new();
 
         /// <summary>
         /// A collection of link pairs, with the name and url of each link. May be empty.

--- a/src/Hive/Models/User.cs
+++ b/src/Hive/Models/User.cs
@@ -46,7 +46,7 @@ namespace Hive.Models
         /// </summary>
         [Column(TypeName = "jsonb")]
         [JsonConverter(typeof(ArbitraryAdditionalData.ArbitraryAdditionalDataConverter))]
-        public ArbitraryAdditionalData AdditionalData { get; } = new();
+        public ArbitraryAdditionalData AdditionalData { get; set; } = new();
 
         /// <summary>
         /// Configures for EF

--- a/src/Hive/Services/Common/ChannelService.cs
+++ b/src/Hive/Services/Common/ChannelService.cs
@@ -205,8 +205,6 @@ namespace Hive.Services.Common
                 return new HiveObjectQuery<Channel>(StatusCodes.Status409Conflict, "A channel with this name already exists.");
 
             // Call our hooks
-            newChannel.AdditionalData.Add("test", "data");
-            newChannel.AdditionalData.Add("test2", 32);
             combined.NewChannelCreated(newChannel);
 
             _ = await context.Channels.AddAsync(newChannel).ConfigureAwait(false);

--- a/src/Hive/Startup.cs
+++ b/src/Hive/Startup.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NodaTime;
+using NodaTime.Serialization.SystemTextJson;
 using Serilog;
 
 namespace Hive
@@ -102,14 +103,18 @@ namespace Hive
 
         private static JsonSerializerOptions ConstructHiveJsonSerializerOptions()
         {
-            var options = new JsonSerializerOptions
+            var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
             {
                 // We need to explicitly include fields for some ValueTuples to deserialize properly
-                IncludeFields = true
-            };
+                IncludeFields = true,
+            }
+            // Use Bcl time zone for Noda Time
+            .ConfigureForNodaTime(DateTimeZoneProviders.Bcl);
 
             // Add AdditionalData converter
             options.Converters.Add(ArbitraryAdditionalData.Converter);
+            // Add AdditionalData converter
+            options.Converters.Add(NodaConverters.InstantConverter);
 
             return options;
         }

--- a/src/Hive/Startup.cs
+++ b/src/Hive/Startup.cs
@@ -55,7 +55,7 @@ namespace Hive
             container.RegisterInstance<IClock>(SystemClock.Instance);
             container.Register<Permissions.Logging.ILogger, Logging.PermissionsProxy>();
             container.Register(Made.Of(() => new PermissionsManager<PermissionContext>(Arg.Of<IRuleProvider>(), Arg.Of<Permissions.Logging.ILogger>(), ".")), Reuse.Singleton);
-            container.Register<SymmetricAlgorithm>(made: Made.Of(() => Rijndael.Create()));
+            container.Register<SymmetricAlgorithm>(Reuse.Singleton, made: Made.Of(() => Rijndael.Create()));
 
             if (Configuration.GetSection("Auth0").Exists())
             {


### PR DESCRIPTION
- `JsonSerializerOptions` is now directly injected via DryIOC instead of being wrapped by some JsonOptions BS
- Main hive classes that use `JsonSerializerOptions` should now be using our injected `JsonSerializerOptions`
- Fix tuples not being de/serialized with `IncludeFields`
- Fix GameVersionsController POST endpoint being mapped to `/new` instead of `/api/game/versions/new`
- Fix uploading bullshit having `SymmetricAlgorithm` being singleton
- Fix AdditionalData not being read from EF Core by adding AdditionalData setters to each EF Model
- Fix EF Core not de/serializing AdditionalData in the first place by shoving our JSON Converter up Npgsql's ass