### PR TITLE
Fix Permissions Manager and Friends

### DIFF
--- a/src/Hive/Extensions/RegisterFunctionExtensions.cs
+++ b/src/Hive/Extensions/RegisterFunctionExtensions.cs
@@ -1,0 +1,23 @@
+﻿using DryIoc;
+using System;
+
+namespace Hive.Extensions
+{
+    /// <summary>
+    /// Extensions for <see cref="IContainer"/> for registering custom functions to the Permissions System.
+    /// </summary>
+    public static class RegisterFunctionExtensions
+    {
+        /// <summary>
+        /// Registers a custom builtin function to the Permission System.
+        /// </summary>
+        /// <remarks>
+        /// Shorthand for <code>IContainer.RegisterInstance((name, impl))</code>
+        /// </remarks>
+        /// <param name="container">The <see cref="IContainer"/> to inject our function into.</param>
+        /// <param name="name">Function name</param>
+        /// <param name="impl">Function implementation</param>
+        public static void RegisterBuiltinFunction(this IContainer container, string name, Delegate impl)
+            => container.RegisterInstance((name, impl));
+    }
+}

--- a/src/Hive/Properties/launchSettings.json
+++ b/src/Hive/Properties/launchSettings.json
@@ -11,7 +11,7 @@
   "profiles": {
     "Hive": {
       "commandName": "Project",
-      "workingDirectory": "..\\..\\artifacts\\bin\\Hive\\Debug\\net5.0",
+      "workingDirectory": "..\\..\\artifacts\\bin\\Hive\\Debug\\net6.0",
       "launchBrowser": true,
       "launchUrl": "api/channels",
       "environmentVariables": {

--- a/src/Hive/Services/Common/ModService.cs
+++ b/src/Hive/Services/Common/ModService.cs
@@ -67,9 +67,6 @@ namespace Hive.Services.Common
         private readonly IAggregate<IModsPlugin> plugin;
         private readonly PermissionsManager<PermissionContext> permissions;
 
-        // Actions done on a list of mods
-        private const string FilterModsActionName = "hive.mods.filter";
-
         // Actions done on a singular mod
         private const string FilterModActionName = "hive.mod.filter";
 
@@ -121,7 +118,7 @@ namespace Hive.Services.Common
 
             // Further filter these mods by both a permissions check and a plugin check
             filteredMods = filteredMods.Where(m =>
-                permissions.CanDo(FilterModsActionName, new PermissionContext { User = user, Mod = m }, ref getModsParseState)
+                permissions.CanDo(FilterModActionName, new PermissionContext { User = user, Mod = m }, ref getModsParseState)
                         && combined.GetSpecificModAdditionalChecks(user, m));
 
             return new HiveObjectQuery<IEnumerable<Mod>>(StatusCodes.Status200OK, filteredMods);

--- a/src/Hive/Startup.cs
+++ b/src/Hive/Startup.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text.Json;
 using DryIoc;
@@ -80,7 +81,7 @@ namespace Hive
             container.RegisterInstance<IClock>(SystemClock.Instance);
             container.Register<JsonSerializerOptions>(Reuse.Singleton, made: Made.Of(() => ConstructHiveJsonSerializerOptions()));
             container.Register<Permissions.Logging.ILogger, Logging.PermissionsProxy>();
-            container.Register(Made.Of(() => new PermissionsManager<PermissionContext>(Arg.Of<IRuleProvider>(), Arg.Of<Permissions.Logging.ILogger>(), ".")), Reuse.Singleton);
+            container.Register(Made.Of(() => new PermissionsManager<PermissionContext>(Arg.Of<IRuleProvider>(), Arg.Of<Permissions.Logging.ILogger>(), ".", Arg.Of<IEnumerable<(string, Delegate)>>())), Reuse.Singleton);
             container.Register<SymmetricAlgorithm>(Reuse.Singleton, made: Made.Of(() => Aes.Create()));
 
             if (Configuration.GetSection("Auth0").Exists())

--- a/src/Hive/Startup.cs
+++ b/src/Hive/Startup.cs
@@ -81,7 +81,8 @@ namespace Hive
             container.RegisterInstance<IClock>(SystemClock.Instance);
             container.Register<JsonSerializerOptions>(Reuse.Singleton, made: Made.Of(() => ConstructHiveJsonSerializerOptions()));
             container.Register<Permissions.Logging.ILogger, Logging.PermissionsProxy>();
-            container.Register(Made.Of(() => new PermissionsManager<PermissionContext>(Arg.Of<IRuleProvider>(), Arg.Of<Permissions.Logging.ILogger>(), ".", Arg.Of<IEnumerable<(string, Delegate)>>())), Reuse.Singleton);
+            container.Register(Made.Of(() => new PermissionsManager<PermissionContext>(Arg.Of<IRuleProvider>(),
+                    Arg.Of<Permissions.Logging.ILogger>(), ".", Arg.Of<IEnumerable<(string, Delegate)>>())), Reuse.Singleton);
             container.Register<SymmetricAlgorithm>(Reuse.Singleton, made: Made.Of(() => Aes.Create()));
 
             if (Configuration.GetSection("Auth0").Exists())


### PR DESCRIPTION
This PR performs the following fixes:
- Changes the `PermissionsManager` constructor in DryIoc to allow an injected `IEnumerable<(string, Delegate)>`
  - Thus allowing external plugins (Like Tags) to register their own functions for the permissions system
  - This works fine on a very barebones Hive instance (with only a Rule Provider plugin installed so Hive can start)
- Added a wrapper method for registering new functions for the permission system
- Combine `hive.mods.filter` and `hive.mod.filter` permission rules into *just* `hive.mod.filter`
- Fix launchSettings.json to use the `net6.0` working directory
  - I guess I had to explicitly change this so VS Debugging actually pointed to the right directory