### PR TITLE
Assign an empty GUID to the first mod's user.

### DIFF
--- a/src/Hive/Program.cs
+++ b/src/Hive/Program.cs
@@ -171,7 +171,7 @@ namespace Hive
                     ReadableID = "test-mod",
                     Version = new Version("0.1.0"),
                     UploadedAt = SystemClock.Instance.GetCurrentInstant(),
-                    Uploader = new User { Username = "me" },
+                    Uploader = new User { Username = "me", AlternativeId = Guid.Empty.ToString() },
                     Channel = channel,
                     DownloadLink = new Uri("file:///"),
                 };


### PR DESCRIPTION
As of right now, Hive won't finish initializing on debug for the first time (the DB requires `AlternativeId` to not be null). This assigns it a value.