### PR TITLE
Added Web Config Options

### DIFF
--- a/docs/Hive/Configuration.md
+++ b/docs/Hive/Configuration.md
@@ -8,6 +8,7 @@ This is a quick landing page for Hive's configuration. Further documentation can
 - [Restricting Non-Authenticated Users](Configuration/GuestRestrictionMiddleware.md)
 - [Auth0](Configuration/Auth0.md)
 - [Uploads](Configuration/Uploads.md)
+- [Web](Configuration/Web.md)
 
 ## Root Configuration Options
 

--- a/docs/Hive/Configuration/Web.md
+++ b/docs/Hive/Configuration/Web.md
@@ -1,0 +1,44 @@
+# Web Configuration Options
+
+## Configuration Header
+
+`Web`
+
+If this configuration section is not present, CORS will be disabled and HTTPS Redirection will be enabled.
+
+## Sample configuration
+
+```json
+"Web": {
+    "CORS": true,
+    "AllowedOrigins": ["https://example.com", "https://localhost:3000"],
+    "AllowedMethods": ["GET", "POST", "PUT"],
+    "AllowedHeaders": ["Content-Type", "x-requested-with"],
+    "PolicyName": "_hiveOrigins",
+    "HTTPSRedirection": true
+}
+```
+
+## `CORS` - `boolean`
+
+Whether or not to enable CORS. If disabled, the Allowed\* and PolicyName fields are ignored. If not present, will default to `false`.
+
+## `AllowedOrigins` - `string[]`
+
+The origins to allow through CORS. If CORS is enabled, this is required. You cannot allow all origins, as then you wouldn't be able to use the authorization headers in Hive.
+
+## `AllowedMethods` - `string[]`
+
+The methods to allow through CORS. If not present or if it has no items, it will allow any method.
+
+## `AllowedHeaders` - `string[]`
+
+The headers to allow through CORS. If not present or if it has no items, it will allow any header.
+
+## `PolicyName` - `string`
+
+The CORS policy name. If not present, will default to `_hiveOrigins`
+
+## `HTTPSRedirection` - `boolean`
+
+Whether or not to enable HTTPS Redirection. If not present, will default to `true`.

--- a/src/Hive/Configuration/WebOptions.cs
+++ b/src/Hive/Configuration/WebOptions.cs
@@ -39,9 +39,9 @@ public class WebOptions
     public List<string>? AllowedHeaders { get; private set; }
 
     /// <summary>
-    /// The CORS policy name. Defaults to "_hive"
+    /// The CORS policy name. Defaults to "_hiveOrigins"
     /// </summary>
-    public string PolicyName { get; set; } = "_hive";
+    public string PolicyName { get; set; } = "_hiveOrigins";
 
     /// <summary>
     /// Enables https redirection. Defaults to true.

--- a/src/Hive/Configuration/WebOptions.cs
+++ b/src/Hive/Configuration/WebOptions.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Hive.Configuration;
+
+/// <summary>
+/// Represents configuration for configuring Hive specific attributes
+/// </summary>
+public class WebOptions
+{
+    /// <summary>
+    /// The config header to look under for this configuration instance.
+    /// </summary>
+    public const string ConfigHeader = "Web";
+
+    /// <summary>
+    /// Enable or disable CORS.
+    /// </summary>
+    public bool CORS { get; set; }
+
+    /// <summary>
+    /// The URLs to allow when processing CORS.
+    /// </summary>
+    [Required]
+    [SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Needed for proper deserialization")]
+    public List<string> AllowedOrigins { get; private set; } = new();
+
+    /// <summary>
+    /// The methods to allow when processing CORS. If this is not filled, it will use any method.
+    /// </summary>
+    [SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Needed for proper deserialization")]
+    public List<string>? AllowedMethods { get; private set; }
+
+    /// <summary>
+    /// The headers to allow when processing CORS. If this is not filled, it will use any header.
+    /// </summary>
+    [SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Needed for proper deserialization")]
+    public List<string>? AllowedHeaders { get; private set; }
+
+    /// <summary>
+    /// The CORS policy name. Defaults to "_hive"
+    /// </summary>
+    public string PolicyName { get; set; } = "_hive";
+
+    /// <summary>
+    /// Enables https redirection. Defaults to true.
+    /// </summary>
+    public bool? HTTPSRedirection { get; private set; }
+}


### PR DESCRIPTION
This PR adds the ability to configure web features in base Hive which I believe are pretty essential. Some of those follow as:

* Enabling or disabling CORS
* Configuring the Origins, Methods, and Headers for CORS
* Setting the CORS Policy Name
* Enabling or disabling HTTPS redirection.