### PR TITLE
Some tweaks to Hive.Versioning

### DIFF
--- a/src/Hive.Utilities/Hive.Utilities.csproj
+++ b/src/Hive.Utilities/Hive.Utilities.csproj
@@ -9,6 +9,8 @@
     
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsUtilities>true</IsUtilities>
+
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Hive.Utilities/LICENSE
+++ b/src/Hive.Utilities/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2022 Atlas Rhythm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. 

--- a/src/Hive.Versioning/Hive.Versioning.csproj
+++ b/src/Hive.Versioning/Hive.Versioning.csproj
@@ -12,6 +12,8 @@
     <VersionPrefix>0.1.0</VersionPrefix>
     <DoesBuildStandalone>true</DoesBuildStandalone>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(BuildingStandalone)' == 'true'">

--- a/src/Hive.Versioning/LICENSE
+++ b/src/Hive.Versioning/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2022 Atlas Rhythm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. 

--- a/src/Hive.Versioning/Parsing/ErrorMessages.cs
+++ b/src/Hive.Versioning/Parsing/ErrorMessages.cs
@@ -18,7 +18,7 @@ namespace Hive.Versioning.Parsing
     /// <summary>
     /// A class containing helpers for getting user-friendly parser error messages given a populated <see cref="ParserErrorState{TAction}"/>.
     /// </summary>
-    public static class ErrorMessages
+    internal static class ErrorMessages
     {
         private record GeneratedMessage(string Message,
             string? Suggestion = null,

--- a/src/Hive.Versioning/Parsing/ParserErrorState.cs
+++ b/src/Hive.Versioning/Parsing/ParserErrorState.cs
@@ -14,7 +14,7 @@ namespace Hive.Versioning.Parsing
     /// An error action reported while parsing a version or version range.
     /// </summary>
     /// <typeparam name="TAction">The action type being used.</typeparam>
-    public struct ActionErrorReport<TAction> : IEquatable<ActionErrorReport<TAction>>
+    internal struct ActionErrorReport<TAction> : IEquatable<ActionErrorReport<TAction>>
         where TAction : struct
     {
         /// <summary>
@@ -83,7 +83,7 @@ namespace Hive.Versioning.Parsing
     /// If this type is default constructed, errors will not be reported.
     /// </remarks>
     /// <typeparam name="TAction">The action type to use for reports.</typeparam>
-    public ref struct ParserErrorState<TAction>
+    internal ref struct ParserErrorState<TAction>
         where TAction : struct
     {
         /// <summary>

--- a/src/Hive.Versioning/Parsing/RangeParser.cs
+++ b/src/Hive.Versioning/Parsing/RangeParser.cs
@@ -21,7 +21,7 @@ namespace Hive.Versioning.Parsing
     /// <summary>
     /// The parse actions for version range parsing.
     /// </summary>
-    public enum RangeParseAction
+    internal enum RangeParseAction
     {
         /// <summary>
         /// No action.
@@ -128,7 +128,7 @@ namespace Hive.Versioning.Parsing
     /// <summary>
     /// A parse action that can be either a <see cref="RangeParseAction"/> or a <see cref="VersionParseAction"/>.
     /// </summary>
-    public readonly struct AnyParseAction : IEquatable<AnyParseAction>
+    internal readonly struct AnyParseAction : IEquatable<AnyParseAction>
     {
         /// <summary>
         /// The value of this action, as a <see cref="RangeParseAction"/>.

--- a/src/Hive.Versioning/Parsing/VersionParser.cs
+++ b/src/Hive.Versioning/Parsing/VersionParser.cs
@@ -18,7 +18,7 @@ namespace Hive.Versioning.Parsing
     /// <summary>
     /// The parse actions for version parsing.
     /// </summary>
-    public enum VersionParseAction
+    internal enum VersionParseAction
     {
         /// <summary>
         /// No action.

--- a/src/Hive.Versioning/VersionRange.cs
+++ b/src/Hive.Versioning/VersionRange.cs
@@ -690,31 +690,33 @@ namespace Hive.Versioning
         public static bool TryParse(string text, [MaybeNullWhen(false)] out VersionRange range)
             => TryParse(text.AsSpan(), out range);
         /// <summary>
-        /// Attempts to parse a whole string as a <see cref="VersionRange"/>, optionally recording error information.
+        /// Attempts to parse a whole string as a <see cref="VersionRange"/>.
         /// </summary>
         /// <remarks>
         /// <include file="docs.xml" path='csdocs/class[@name="VersionRange"]/syntax/*'/>
         /// </remarks>
-        /// <param name="errors">The error state object to write error information to.</param>
         /// <param name="text">The string to try to parse.</param>
         /// <param name="range">The parsed <see cref="VersionRange"/>, if any.</param>
+        /// <param name="error">An error message describing the parse error, if any.</param>
+        /// <param name="fullErrorMessages"><see langword="true"/> to attempt to give a complete error message, <see langword="false"/> otherwise.</param>
         /// <returns><see langword="true"/> if <paramref name="text"/> was successfully parsed, <see langword="false"/> otherwise.</returns>
-        /// <seealso cref="TryParse(ref ErrorState, ref StringPart, out VersionRange)"/>
-        public static bool TryParse(ref ErrorState errors, StringView text, [MaybeNullWhen(false)] out VersionRange range)
-            => TryParse(ref errors, text.AsSpan(), out range);
+        /// <seealso cref="TryParse(ref StringPart, out VersionRange)"/>
+        public static bool TryParse(StringView text, [MaybeNullWhen(false)] out VersionRange range, [MaybeNullWhen(true)] out string error, bool fullErrorMessages = true)
+            => TryParse(text.AsSpan(), out range, out error, fullErrorMessages);
         /// <summary>
-        /// Attempts to parse a whole string as a <see cref="VersionRange"/>, optionally recording error information.
+        /// Attempts to parse a whole string as a <see cref="VersionRange"/>.
         /// </summary>
         /// <remarks>
         /// <include file="docs.xml" path='csdocs/class[@name="VersionRange"]/syntax/*'/>
         /// </remarks>
-        /// <param name="errors">The error state object to write error information to.</param>
         /// <param name="text">The string to try to parse.</param>
         /// <param name="range">The parsed <see cref="VersionRange"/>, if any.</param>
+        /// <param name="error">An error message describing the parse error, if any.</param>
+        /// <param name="fullErrorMessages"><see langword="true"/> to attempt to give a complete error message, <see langword="false"/> otherwise.</param>
         /// <returns><see langword="true"/> if <paramref name="text"/> was successfully parsed, <see langword="false"/> otherwise.</returns>
-        /// <seealso cref="TryParse(ref ErrorState, ref StringPart, out VersionRange)"/>
-        public static bool TryParse(ref ErrorState errors, string text, [MaybeNullWhen(false)] out VersionRange range)
-            => TryParse(ref errors, text.AsSpan(), out range);
+        /// <seealso cref="TryParse(ref StringPart, out VersionRange)"/>
+        public static bool TryParse(string text, [MaybeNullWhen(false)] out VersionRange range, [MaybeNullWhen(true)] out string error, bool fullErrorMessages = true)
+            => TryParse(text.AsSpan(), out range, out error, fullErrorMessages);
 #endif
 
         /// <summary>
@@ -754,6 +756,24 @@ namespace Hive.Versioning
         }
 
         /// <summary>
+        /// Attempts to parse a whole string as a <see cref="VersionRange"/>.
+        /// </summary>
+        /// <remarks>
+        /// <include file="docs.xml" path='csdocs/class[@name="VersionRange"]/syntax/*'/>
+        /// </remarks>
+        /// <param name="text">The string to try to parse.</param>
+        /// <param name="range">The parsed <see cref="VersionRange"/>, if any.</param>
+        /// <param name="error">An error message describing the parse error, if any.</param>
+        /// <param name="fullErrorMessages"><see langword="true"/> to attempt to give a complete error message, <see langword="false"/> otherwise.</param>
+        /// <returns><see langword="true"/> if <paramref name="text"/> was successfully parsed, <see langword="false"/> otherwise.</returns>
+        /// <seealso cref="TryParse(ref StringPart, out VersionRange)"/>
+        public static bool TryParse(StringPart text, [MaybeNullWhen(false)] out VersionRange range, [MaybeNullWhen(true)] out string error, bool fullErrorMessages = true)
+        {
+            text = text.Trim();
+            return TryParse(ref text, true, out range, out error, fullErrorMessages);
+        }
+
+        /// <summary>
         /// Attempts to parse a whole string as a <see cref="VersionRange"/>, optionally recording error information.
         /// </summary>
         /// <remarks>
@@ -764,7 +784,7 @@ namespace Hive.Versioning
         /// <param name="range">The parsed <see cref="VersionRange"/>, if any.</param>
         /// <returns><see langword="true"/> if <paramref name="text"/> was successfully parsed, <see langword="false"/> otherwise.</returns>
         /// <seealso cref="TryParse(ref ErrorState, ref StringPart, out VersionRange)"/>
-        public static bool TryParse(ref ErrorState errors, StringPart text, [MaybeNullWhen(false)] out VersionRange range)
+        internal static bool TryParse(ref ErrorState errors, StringPart text, [MaybeNullWhen(false)] out VersionRange range)
         {
             text = text.Trim();
             return TryParse(ref errors, ref text, true, out range) && text.Length == 0; // report errors
@@ -789,19 +809,41 @@ namespace Hive.Versioning
         }
 
         /// <summary>
-        /// Attempts to parse a <see cref="VersionRange"/> from the start of the string, optionally recording error information.
+        /// Attempts to parse a <see cref="VersionRange"/> from the start of the string.
         /// </summary>
         /// <remarks>
         /// <para>When this returns <see langword="true"/>, <paramref name="text"/> will begin immediately after the parsed <see cref="VersionRange"/>.
         /// When this returns <see langword="false"/>, <paramref name="text"/> will remain unchanged.</para>
         /// <include file="docs.xml" path='csdocs/class[@name="VersionRange"]/syntax/*'/>
         /// </remarks>
-        /// <param name="errors">The error state object to write error information to.</param>
         /// <param name="text">The string to try to parse.</param>
         /// <param name="range">The parsed <see cref="VersionRange"/>, if any.</param>
+        /// <param name="error">An error message describing the parse error, if any.</param>
+        /// <param name="fullErrorMessages"><see langword="true"/> to attempt to give a complete error message, <see langword="false"/> otherwise.</param>
         /// <returns><see langword="true"/> if <paramref name="text"/> was successfully parsed, <see langword="false"/> otherwise.</returns>
         [CLSCompliant(false)]
-        public static bool TryParse(ref ErrorState errors, ref StringPart text, [MaybeNullWhen(false)] out VersionRange range)
+        public static bool TryParse(ref StringPart text, [MaybeNullWhen(false)] out VersionRange range, [MaybeNullWhen(true)] out string error, bool fullErrorMessages = true)
+            => TryParse(ref text, false, out range, out error, fullErrorMessages);
+
+        internal static bool TryParse(ref StringPart text, bool checkLength,
+            [MaybeNullWhen(false)] out VersionRange range, [MaybeNullWhen(true)] out string error, bool fullErrorMessages = true)
+        {
+            var errors = new ErrorState(text);
+            if (TryParse(ref errors, ref text, checkLength, out range))
+            {
+                error = null;
+                errors.Dispose();
+                return true;
+            }
+            else
+            {
+                error = ErrorMessages.GetVersionRangeErrorMessage(ref errors, fullErrorMessages);
+                errors.Dispose();
+                return false;
+            }
+        }
+
+        internal static bool TryParse(ref ErrorState errors, ref StringPart text, [MaybeNullWhen(false)] out VersionRange range)
             => TryParse(ref errors, ref text, false, out range);
 
         private static bool TryParse(ref ErrorState errors, ref StringPart text, bool checkLength, [MaybeNullWhen(false)] out VersionRange range)

--- a/src/Hive/Services/Common/ModService.cs
+++ b/src/Hive/Services/Common/ModService.cs
@@ -189,7 +189,7 @@ namespace Hive.Services.Common
             var modVersion = AttemptParseVersionWithError(identifier.Version, out var error);
             if (modVersion == null)
             {
-                return new(StatusCodes.Status400BadRequest, error);
+                return new(StatusCodes.Status400BadRequest, error ?? "");
             }
 
             var modId = identifier.ID;
@@ -338,21 +338,16 @@ namespace Hive.Services.Common
             return filteredMods;
         }
 
-        private static Version? AttemptParseVersionWithError(string version, out string error)
+        private static Version? AttemptParseVersionWithError(string version, out string? error)
         {
-            var versionSpan = version.AsSpan();
-            var errorState = new ParserErrorState<VersionParseAction>(in versionSpan);
-
-            if (!Version.TryParse(ref errorState, versionSpan, out var parsedVersion))
+            if (Version.TryParse(version, out var parsedVersion, out error))
             {
-                error = ErrorMessages.GetVersionErrorMessage(ref errorState);
-                errorState.Dispose();
+                return parsedVersion;
+            }
+            else
+            {
                 return null;
             }
-
-            errorState.Dispose();
-            error = string.Empty;
-            return parsedVersion;
         }
 
         // Abstracts the construction of a Mod access query with necessary Include calls to a helper function


### PR DESCRIPTION
The notable API changes involve the addition of overloads of `TryParse` which return the error message that would have been in the exception thrown by `Parse`, and making all of the error info based APIs internal due to the difficulty of using them correctly. They were only exposed to allow access to error messages in the first place, and now that that is available as overloads, they no longer need to be public.

This also relicenses Hive.Versioning (and Hive.Utilities, by necessity) to MIT like we had discussed quite some time ago.