### PR TITLE
Enable the use of static methods for `Startup.ConfigureContainer` in plugins

### DIFF
--- a/src/Hive.Plugins/Loading/PluginLoader.cs
+++ b/src/Hive.Plugins/Loading/PluginLoader.cs
@@ -157,7 +157,7 @@ namespace Hive.Plugins.Loading
                     {
                         var containerType = configureContainer.GetParameters()[0].ParameterType;
                         var actionType = typeof(Action<>).MakeGenericType(containerType);
-                        var configureDelegate = configureContainer.CreateDelegate(actionType, instance);
+                        var configureDelegate = Delegate.CreateDelegate(actionType, configureContainer.IsStatic ? null : instance, configureContainer);
 
                         _ = typeof(ContainerConfigurator)
                             .GetMethod(nameof(ContainerConfigurator.ConfigureContainerNoCtx))!

--- a/src/Hive/appsettings.Development.json
+++ b/src/Hive/appsettings.Development.json
@@ -11,7 +11,6 @@
 	},
 	"vaulthBaseUri": "https://localhost",
 	"vaulthTimeoutMs": 1000,
-	"RuleSubfolder": "Rules",
 	"AllowedHosts": "*",
 	"UseRateLimiting": false,
 	"ClientRateLimiting": {
@@ -37,5 +36,22 @@
 		"EndpointWhitelist": [],
 		"ClientWhitelist": [],
 		"GeneralRules": []
+	},
+	"Web": {
+		"HTTPSRedirection": false
+	},
+	"Plugins": {
+		"UsePluginSpecificConfig": false,
+		"ExcludePlugins": [],
+		"PluginConfigurations": {
+			"Hive.FileSystemCdnProvider": {
+				"CdnObjectsSubfolder": "C:\\dev\\hive\\cdn\\objects",
+				"CdnMetadataSubfolder": "C:\\dev\\hive\\cdn\\meta",
+				"PublicUrlBase": "file://C/dev/hive/cdn/objects/"
+			},
+			"Hive.FileSystemRuleProvider": {
+				"RuleSubfolder": "rules"
+			}
+		}
 	}
 }

--- a/src/Hive/appsettings.json
+++ b/src/Hive/appsettings.json
@@ -35,7 +35,6 @@
 			"Application": "Hive"
 		}
 	},
-	"RuleSubfolder": "Rules",
 	"AllowedHosts": "*",
 	"PathBase": "/",
 	"UseRateLimiting": true,


### PR DESCRIPTION
Previously, because we were passing the plugin startup instance to the `CreateDelegate` call in all cases, static methods were not permitted, instead throwing a cryptic error. `Hive.Tags` uses a static `ConfigureContainer`, because it does not need access to the configuration passed to the startup. This should be supported.