### PR TITLE
Implement dependency load chains for plugins

### DIFF
--- a/src/Hive.Plugins/Hive.Plugins.csproj
+++ b/src/Hive.Plugins/Hive.Plugins.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
   </ItemGroup>
   

--- a/src/Hive.Plugins/Loading/PluginInstance.cs
+++ b/src/Hive.Plugins/Loading/PluginInstance.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Reflection;
+using Microsoft.Extensions.DependencyModel;
 
 namespace Hive.Plugins.Loading
 {
@@ -20,12 +21,15 @@ namespace Hive.Plugins.Loading
         /// Gets the name of the plugin.
         /// </summary>
         public string Name => LoadContext.Name!;
+
         internal PluginLoadContext LoadContext { get; }
+        internal DependencyContext DependencyContext { get; }
 
         internal PluginInstance(PluginLoadContext context)
         {
             LoadContext = context;
             PluginAssembly = context.LoadPlugin();
+            DependencyContext = DependencyContext.Load(PluginAssembly);
         }
     }
 }

--- a/src/Hive.Plugins/Loading/PluginLoadContext.cs
+++ b/src/Hive.Plugins/Loading/PluginLoadContext.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
+using System.Threading;
 using Hive.Plugins.Resources;
 
 namespace Hive.Plugins.Loading
@@ -10,6 +12,7 @@ namespace Hive.Plugins.Loading
     internal class PluginLoadContext : AssemblyLoadContext
     {
         private readonly AssemblyDependencyResolver resolver;
+        private readonly List<PluginLoadContext> depencencyContexts = new();
 
         public PluginLoadContext(DirectoryInfo directory)
             : base((directory ?? throw new ArgumentNullException(nameof(directory))).Name, false)
@@ -31,12 +34,39 @@ namespace Hive.Plugins.Loading
         public Assembly LoadPlugin()
             => LoadFromAssemblyPath(MainFile.FullName);
 
+        internal void AddDependencyContext(PluginLoadContext ctx)
+            => depencencyContexts.Add(ctx);
+
+        private readonly ThreadLocal<bool> isResolving = new(static () => false);
+
         protected override Assembly? Load(AssemblyName assemblyName)
         {
+            // if this condition triggers, then we're in a cycle
+            // returning immediately will break that cycle
+            if (isResolving.Value)
+                return null;
+
             var path = resolver.ResolveAssemblyToPath(assemblyName);
             if (path is not null)
             {
                 return LoadFromAssemblyPath(path);
+            }
+
+            // if we couldn't find it in *our* ALC, we want to try to find it in our *dependencies'* ALCs, before finally falling back to the default ALC
+            try
+            {
+                isResolving.Value = true;
+
+                foreach (var dep in depencencyContexts)
+                {
+                    var asm = dep.Load(assemblyName);
+                    if (asm is not null)
+                        return asm;
+                }
+            }
+            finally
+            {
+                isResolving.Value = false;
             }
 
             return null; // cannot load the assembly in this ALC

--- a/src/Hive.Plugins/Loading/PluginLoadContext.cs
+++ b/src/Hive.Plugins/Loading/PluginLoadContext.cs
@@ -9,7 +9,7 @@ using Hive.Plugins.Resources;
 
 namespace Hive.Plugins.Loading
 {
-    internal class PluginLoadContext : AssemblyLoadContext
+    internal class PluginLoadContext : AssemblyLoadContext, IDisposable
     {
         private readonly AssemblyDependencyResolver resolver;
         private readonly List<PluginLoadContext> depencencyContexts = new();
@@ -81,6 +81,34 @@ namespace Hive.Plugins.Loading
             }
 
             return IntPtr.Zero; // cannot load the dll in this ALC
+        }
+
+        private bool disposedValue;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    isResolving.Dispose();
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        // ~PluginLoadContext()
+        // {
+        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        //     Dispose(disposing: false);
+        // }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
Currently, if a plugin depends on another plugin, either type loading will fail, or another instance of that plugin will be loaded. Neither of these are desirable, as they both cause the plugins to fail to operate correctly. This creates a dependency chain in the ALCs so that a load in a plugin ALC tries to load an assembly in all of its dependencies' ALCs.