### PR TITLE
Ensure management API info is cached program-wide

### DIFF
--- a/src/Hive/Services/Common/InMemoryInformationContext.cs
+++ b/src/Hive/Services/Common/InMemoryInformationContext.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace Hive.Services.Common;
+
+internal class InMemoryInformationContext : IInformationContext
+{
+    private readonly ConcurrentDictionary<string, object> _contexts = new();
+
+    public void SetValue<T>(string key, T value)
+    {
+        if (key is null)
+            throw new ArgumentNullException(nameof(key));
+
+        if (value is null)
+            throw new ArgumentNullException(nameof(value));
+
+        _ = _contexts.TryAdd(key, value);
+    }
+
+    public bool TryGetValue<T>(string key, out T? value)
+    {
+        if (key is null)
+            throw new ArgumentNullException(nameof(key));
+
+        var result = _contexts.TryGetValue(key, out var val);
+        value = result ? (T?)val : default;
+        return result;
+    }
+}

--- a/src/Hive/Services/IInformationContext.cs
+++ b/src/Hive/Services/IInformationContext.cs
@@ -1,0 +1,24 @@
+﻿namespace Hive.Services;
+
+/// <summary>
+/// Stores arbitrary information for any container, in any context.
+/// </summary>
+public interface IInformationContext
+{
+    /// <summary>
+    /// Checks and possibly returns a value in the context
+    /// </summary>
+    /// <typeparam name="T">The type of the object to retrieve.</typeparam>
+    /// <param name="key">The key to retrieve the object by.</param>
+    /// <param name="value">The object.</param>
+    /// <returns>Whether or not the object exists in this context.</returns>
+    bool TryGetValue<T>(string key, out T? value);
+
+    /// <summary>
+    /// Sets a value within the context.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to store.</typeparam>
+    /// <param name="key">They key to store the object under.</param>
+    /// <param name="value">The object.</param>
+    void SetValue<T>(string key, T value);
+}

--- a/src/Hive/Startup.cs
+++ b/src/Hive/Startup.cs
@@ -127,6 +127,7 @@ namespace Hive
             container.Register<GameVersionService>(Reuse.Scoped);
             container.Register<DependencyResolverService>(Reuse.Scoped);
             container.Register(typeof(IAggregate<>), typeof(Aggregate<>), Reuse.Singleton);
+            container.Register<IInformationContext, InMemoryInformationContext>(Reuse.Singleton);
 
             container.RegisterHiveGraphQL();
         }


### PR DESCRIPTION
There was a bug that caused the application to request a new Machine to Machine access token every time a request to our API was made by an authenticated user.

This PR introduces a "lightweight container" service which just holds arbitrary data across the application, suitable for cases where we (or any plugin developers) need to store infrequently updated data that doesn't make as much sense to include in the database.