### PR TITLE
Move graphql endpoint under "/api"

### DIFF
--- a/src/Hive/Startup.cs
+++ b/src/Hive/Startup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text.Json;
 using DryIoc;
+using GraphQL.Server.Ui.Altair;
 using Hive.Configuration;
 using Hive.Controllers;
 using Hive.Graphing;
@@ -164,8 +165,8 @@ namespace Hive
             }
 
             _ = app.UseAuthentication()
-                .UseGraphQL<HiveSchema>("/graphql")
-                .UseGraphQLAltair()
+                .UseGraphQL<HiveSchema>("/api/graphql")
+                .UseGraphQLAltair(new AltairOptions { GraphQLEndPoint = "/api/graphql" })
                 .UseEndpoints(endpoints => endpoints.MapControllers());
 
 


### PR DESCRIPTION
Self-explanatory. This makes it easier on the frontend to do URL replacements and overall reduces complexity for whenever we need to setup a reverse proxy, as every other endpoint in the base Hive is manually prefixed with `/api`