### PR TITLE
Feat/finalized upload returns mod

### DIFF
--- a/src/Hive.Tests/Endpoints/UploadController.cs
+++ b/src/Hive.Tests/Endpoints/UploadController.cs
@@ -125,6 +125,7 @@ namespace Hive.Tests.Endpoints
             Assert.NotNull(result2);
             Assert.Null(result2.Result);
             Assert.Equal(Controllers.UploadController.ResultType.Success, result2.Value.Type);
+            Assert.NotNull(result2.Value.ExtractedData);
 
             var db = serviceProvider.GetRequiredService<HiveContext>();
 

--- a/src/Hive/Controllers/UploadController.cs
+++ b/src/Hive/Controllers/UploadController.cs
@@ -577,7 +577,7 @@ namespace Hive.Controllers
 
             logger.Information("Upload {ID} complete: {Name} by {Author}", cookie.Substring(0, 16), localization.Name, modObject.Uploader.Username);
 
-            return UploadResult.Finish();
+            return UploadResult.Finish(modObject);
         }
     }
 }

--- a/src/Hive/Controllers/UploadController.cs
+++ b/src/Hive/Controllers/UploadController.cs
@@ -249,7 +249,7 @@ namespace Hive.Controllers
             public object? ErrorContext { get; init; }
 
             /// <summary>
-            /// The mod data extracted during the first stage of the upload flow.
+            /// The mod data associated with this upload.
             /// </summary>
             [JsonPropertyName("data")]
             [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -319,10 +319,11 @@ namespace Hive.Controllers
                 };
             }
 
-            internal static UploadResult Finish()
+            internal static UploadResult Finish(Mod mod)
                 => new()
                 {
-                    Type = ResultType.Success
+                    Type = ResultType.Success,
+                    ExtractedData = SerializedMod.Serialize(mod, mod.Localizations.FirstOrDefault())
                 };
         }
 


### PR DESCRIPTION
A plugin can mutate any of the properties of an uploaded mod, there's no guarantee that the ID a consumer submits in the upload step will be the same ID of the mod after the upload step.

This PR introduces returning the finalized mod data in the request endpoint so the consumer can guarantee that "the thing I just uploaded" can be referenced immediately.