### PR TITLE
Auth0 Refactor

### DIFF
--- a/src/Hive/Controllers/Auth0Controller.cs
+++ b/src/Hive/Controllers/Auth0Controller.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using Hive.Configuration;
 using Hive.Models;
 using Hive.Services;
 using Microsoft.AspNetCore.Http;
@@ -52,7 +51,7 @@ namespace Hive.Controllers
         public async Task<ActionResult<Auth0TokenResponse?>> Callback([FromQuery] string code, [FromQuery] Uri redirectUri)
         {
             var val = await auth0Service.RequestToken(code, redirectUri).ConfigureAwait(false);
-            return val is null ? Unauthorized() : (ActionResult<Auth0TokenResponse?>)Ok(val);
+            return val is null ? Unauthorized() : Ok(val);
         }
     }
 }

--- a/src/Hive/Controllers/UploadController.cs
+++ b/src/Hive/Controllers/UploadController.cs
@@ -422,7 +422,7 @@ namespace Hive.Controllers
             var cdnObject = await cdn.UploadObject(file.FileName, memStream, nodaClock.GetCurrentInstant() + Duration.FromHours(1)).ConfigureAwait(false);
 
             var uploadResult = UploadResult.Confirm(tokenAlgorithm, modData, cdnObject);
-            logger.Information("First stage of mod upload complete (cookie {ID})", uploadResult.ActionCookie!.Substring(0, 16));
+            logger.Information("First stage of mod upload complete (cookie {ID})", uploadResult.ActionCookie![..16]);
 
             // this method encrypts the extracted data into a cookie in the resulting object that is sent along
             return uploadResult;
@@ -464,7 +464,7 @@ namespace Hive.Controllers
              || finalMetadata.SupportedGameVersions is null || finalMetadata.SupportedGameVersions.Count < 1)
                 return BadRequest("Missing metadata keys");
 
-            logger.Information("Completing upload {ID}", cookie.Substring(0, 16));
+            logger.Information("Completing upload {ID}", cookie[..16]);
 
             // decrypt the token
             var payload = await EncryptedUploadPayload.ExtractFromCookie(tokenAlgorithm, cookie).ConfigureAwait(false);
@@ -575,7 +575,7 @@ namespace Hive.Controllers
                 await transaction.CommitAsync().ConfigureAwait(false);
             }
 
-            logger.Information("Upload {ID} complete: {Name} by {Author}", cookie.Substring(0, 16), localization.Name, modObject.Uploader.Username);
+            logger.Information("Upload {ID} complete: {Name} by {Author}", cookie[..16], localization.Name, modObject.Uploader.Username);
 
             return UploadResult.Finish(modObject);
         }

--- a/src/Hive/Controllers/UserController.cs
+++ b/src/Hive/Controllers/UserController.cs
@@ -7,6 +7,7 @@ using Hive.Models;
 using Hive.Permissions;
 using Hive.Plugins.Aggregates;
 using Hive.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/src/Hive/Hive.csproj
+++ b/src/Hive/Hive.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="5.0.2" />
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore.SystemTextJson" Version="5.0.2" />
     <PackageReference Include="GraphQL.Server.Ui.Altair" Version="5.0.2" />
+    <PackageReference Include="LitJWT" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.19" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0" Pack="false">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Hive/Services/MockAuthenticationService.cs
+++ b/src/Hive/Services/MockAuthenticationService.cs
@@ -13,7 +13,7 @@ namespace Hive.Services
     /// </summary>
     public class MockAuthenticationService : IProxyAuthenticationService, IAuth0Service
     {
-        private Dictionary<string, User?> Users { get; } = new Dictionary<string, User?>();
+        private Dictionary<string, User?> Users { get; } = new();
 
         /// <inheritdoc/>
         public Auth0ReturnData Data => null!;

--- a/src/Hive/appsettings.Development.json
+++ b/src/Hive/appsettings.Development.json
@@ -46,8 +46,7 @@
 		"PluginConfigurations": {
 			"Hive.FileSystemCdnProvider": {
 				"CdnObjectsSubfolder": "C:\\dev\\hive\\cdn\\objects",
-				"CdnMetadataSubfolder": "C:\\dev\\hive\\cdn\\meta",
-				"PublicUrlBase": "file://C/dev/hive/cdn/objects/"
+				"CdnMetadataSubfolder": "C:\\dev\\hive\\cdn\\meta"
 			},
 			"Hive.FileSystemRuleProvider": {
 				"RuleSubfolder": "rules"


### PR DESCRIPTION
Change auth flow to not request user data from Auth0 on every authenticated request.

I avoided changing any interface contracts to maintain the current auth flow behaviour throughout the API, tests, and website.

* New user data is now only fetched when the initial callback tokens are generated
* We use ASP.NET Core claims for authenticating the user
* Removed everything involving calling the Auth0 Management API (it is no longer necessary)