### PR TITLE
Improved setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A general backend project for modding communities.
 
+## Setup
+
+To setup an instance of Hive, you can follow our [Setup guide](docs/Hive/Setup.md).
+
 ## Building
 
 ### Dependencies
@@ -49,4 +53,4 @@ Update the password fields in `docker-compose.yml`, as well as any other setting
 
 Run the compose file with `docker-compose up`.
 
-Plugins are loaded by mapping a volume with a host machine. See the commented out line in the compose file example.
+Plugins are loaded by mapping a volume with a host machine. See the compose file example.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,11 @@ services:
       # 21034 is the port that Hive can be accessed from the host machine. You are free to change it to something that works for you.
       - "21034:80"
 
-    # volumes:
-    #  - /path/to/hive/plugins:/app/plugins
+    # Plugins are required to use Hive.
+    # Please re-map the host directory (/path/to/hive/plugins) to a location on the machine where plugins will be loaded from.
+    # Leave the second half (/app/plugins) the same!
+    volumes:
+     - /path/to/hive/plugins:/app/plugins
   db:
     image: postgres:12.8
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,17 +17,31 @@ services:
       # Make sure that User ID matches POSTGRES_USER in the [db] service environment.
       # Make sure that Password matches POSTGRES_PASSWORD in the [db] service environment.
       - ConnectionStrings__Default=User ID=postgres;Password=please-change-me;Host=db;Port=5432;Database=hive;Pooling=true;
+      
+      # Plugin configuration can be done using environment variables, formatted as PLUGIN__<Plugin name, "." replaced with "_">__<Configuration key>
+      
+      # See Hive.FileSystemCdnProvider configuration at https://github.com/Atlas-Rhythm/HiveCorePlugins/blob/master/docs/Hive.FileSystemCdnProvider/Configuration.md
+      #   This particular configuration entry defines the public URL that is used to construct download links. Please change it to your public facing URL.
+      - PLUGIN__Hive_FileSystemCdnProvider__PublicUrlBase=please-change-me
     depends_on:
       - db
     ports:
       # 21034 is the port that Hive can be accessed from the host machine. You are free to change it to something that works for you.
       - "21034:80"
 
-    # Plugins are required to use Hive.
-    # Please re-map the host directory (/path/to/hive/plugins) to a location on the machine where plugins will be loaded from.
-    # Leave the second half (/app/plugins) the same!
+    # Please re-map these volumes to directories on your machine.
     volumes:
-     - /path/to/hive/plugins:/app/plugins
+      # Where CDN objects (actual plugins) are stored
+      - /path/to/cdn/objects:/app/cdn/objects
+      
+      # Where metadata about CDN objects are stored
+      - /path/to/cdn/metadata:/app/cdn/metadata 
+      
+      # Where Hive permission rules are stored
+      - /path/to/rules:/app/Rules
+      
+      # Where external Hive plugins will be loaded from
+      #- /path/to/hive/plugins:/app/plugins
   db:
     image: postgres:12.8
     restart: unless-stopped

--- a/docs/Hive/Setup.md
+++ b/docs/Hive/Setup.md
@@ -1,0 +1,35 @@
+# Hive Setup Guide
+
+Follow this setup guide to create your own instance of the Hive back-end.
+
+## Running Hive With Docker
+
+If you are accustomed to using and operating Docker containers, running Hive through Docker may be appealing to you.
+
+Included in the Hive repository is the [`docker-compose.yml`](https://github.com/Atlas-Rhythm/Hive/blob/master/docker-compose.yml) file. To run Hive in a Docker environment, please download this file.
+
+**Do not use this file as-is!**
+
+The Docker Compose file contains the password for the database. Change the password by opening `docker-compose.yml` in any text environment, and editing the `POSTGRES_PASSWORD` field wherever it comes up.
+
+Furthermore, you will need to define a location on the host machine where Hive plugins will be stored and loaded from.
+
+## Downloading Hive
+
+If you do not want to use Docker, you can download the latest release of Hive through [the Releases page](https://github.com/Atlas-Rhythm/Hive/releases).
+
+Simply unzip the Hive release wherever you wish to host Hive.
+
+**Be warned!** You may have to install [PostgreSQL](https://www.postgresql.org/), the database used by Hive. Hive was developed with PostgreSQL 12. Later versions of PostgreSQL may work, but are untested.
+
+## Downloading Plugins
+
+Plugins are an essential part of Hive.
+
+## Setting up Auth0
+
+[Auth0](https://auth0.com/) is an authentication service that Hive supports by default.
+
+An authentication service is required to use Hive. Unless you plan on using a separate authentication plugin, you need to setup Auth0.
+
+[Follow our dedicated Auth0 guide](https://github.com/Atlas-Rhythm/Hive/tree/master/docs/Auth0) to set up Auth0 for your Hive installation. 

--- a/docs/Hive/Setup.md
+++ b/docs/Hive/Setup.md
@@ -63,7 +63,7 @@ Configuration for Hive's core is done through the `appsettings.json` file at the
 
 By default, configuring Hive *plugins* is also done through `appsettings.json`, using a format that looks like this:
 
-```json
+```jsonc
 {
 	"Plugins": {
 		"PluginConfigurations": {
@@ -79,7 +79,8 @@ By default, configuring Hive *plugins* is also done through `appsettings.json`, 
 			// ...and so on.
 		}
 	}
-}```
+}
+```
 
 Plugin configuration can also be done through environment variables, using the format `PLUGIN__<Plugin name, "." replaced with "_">__<Configuration key>`.
 

--- a/docs/Hive/Setup.md
+++ b/docs/Hive/Setup.md
@@ -10,9 +10,9 @@ Included in the Hive repository is the [`docker-compose.yml`](https://github.com
 
 **Do not use this file as-is!**
 
-The Docker Compose file contains the password for the database. Change the password by opening `docker-compose.yml` in any text environment, and editing the `POSTGRES_PASSWORD` field wherever it comes up.
+The Docker Compose file contains some configuration that should be changed before deployment. Please open `docker-compose.yml` in any text environment, and make any necessary modification and configuration to match your deployment environment.
 
-Furthermore, you will need to define a location on the host machine where Hive plugins will be stored and loaded from.
+When you are ready to deploy Hive, run `docker-compose up`.
 
 ## Downloading Hive
 
@@ -20,16 +20,67 @@ If you do not want to use Docker, you can download the latest release of Hive th
 
 Simply unzip the Hive release wherever you wish to host Hive.
 
-**Be warned!** You may have to install [PostgreSQL](https://www.postgresql.org/), the database used by Hive. Hive was developed with PostgreSQL 12. Later versions of PostgreSQL may work, but are untested.
+**Be warned!** You may have to install the [.NET 6 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) and [PostgreSQL 12](https://www.postgresql.org/) to run Hive outside of a Docker container.
 
-## Downloading Plugins
+## Downloading External Plugins
 
-Plugins are an essential part of Hive.
+Plugins are an essential part of Hive. Hive comes with its [own set of core plugins](https://github.com/Atlas-Rhythm/HiveCorePlugins), which comes included with a Docker deployment of Hive.
+
+If you wish to use third party plugins, or need to download Hive core plugins outside of a Docker environment, simply download the latest release from their respective repositories.
+
+Hive expects the `Plugins` folder to be organized. Plugins *must* be included in a subdirectory of the same name, within the `Plugins` folder.
+
+For example, using some of Hive's core plugins, your plugins folder should look like this:
+
+```
+Plugins/
+|- Hive.FileSystemCdnProvider/
+|  |- Hive.FileSystemCdnProvider.dll
+|  |- ...
+|
+|- Hive.FileSystemRuleProvider/
+|  |- Hive.FileSystemRuleProvider.dll
+|  |- ...
+|
+|- Hive.Tags/
+|  |- Hive.Tags.dll
+|  |- ...
+```
+
+**Docker users be warned!** If you want to use third party plugins, you need to map a volume to `/app/plugins` in the Docker container.
 
 ## Setting up Auth0
 
-[Auth0](https://auth0.com/) is an authentication service that Hive supports by default.
-
-An authentication service is required to use Hive. Unless you plan on using a separate authentication plugin, you need to setup Auth0.
+An authentication service is required to use Hive. [Auth0](https://auth0.com/) is Hive's default authentication service. Unless you plan on using a separate authentication plugin, you need to setup Auth0.
 
 [Follow our dedicated Auth0 guide](https://github.com/Atlas-Rhythm/Hive/tree/master/docs/Auth0) to set up Auth0 for your Hive installation. 
+
+## Hive Configuration
+
+Configuration for Hive's core is done through the `appsettings.json` file at the root of the Hive directory.
+
+[We have dedicated documentation pages for configuring the various settings of Hive's core.](https://github.com/Atlas-Rhythm/Hive/blob/master/docs/Hive/Configuration.md)
+
+By default, configuring Hive *plugins* is also done through `appsettings.json`, using a format that looks like this:
+
+```json
+{
+	"Plugins": {
+		"PluginConfigurations": {
+			"Hive.FileSystemCdnProvider": {
+				// Configuration for Hive.FileSystemCdnProvider
+			},
+			"Hive.FileSystemRuleProvider": {
+				// Configuration for Hive.FileSystemRuleProvider
+			},
+			"Hive.Tags": {
+				// Configuration for Hive.Tags
+			}
+			// ...and so on.
+		}
+	}
+}```
+
+Plugin configuration can also be done through environment variables, using the format `PLUGIN__<Plugin name, "." replaced with "_">__<Configuration key>`.
+
+See the [Using Plugins](https://github.com/Atlas-Rhythm/Hive/blob/master/docs/Hive.Plugins/Using.md) page for more information on plugin configuration.


### PR DESCRIPTION
Starting this PR a little early. Documentation may not be as fleshed out as whats needed for proper deployment, hopefully some good reviews would point that out.

This PR introduces new setup documentation for Hive, as well as the following:
- Modified `Dockerfile` to pull in the new HiveCorePlugins docker image.
  - This should allow anyone to deploy Hive using Docker / Docker Compose without needing to manually download and set up Hive core plugins.
- Modified `docker-compose.yml` with more comments and examples for volume mounting and plugin configuration.